### PR TITLE
Ease use of an external FTP server

### DIFF
--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
@@ -178,6 +178,7 @@ class FtpUtil {
 
     static void setPasv(FTPClient ftpClient, boolean usePasv) {
         if (usePasv) {
+            ftpClient.setUseEPSVwithIPv4(true);
             performSilently(ftpClient::enterLocalPassiveMode);
         } else {
             performSilently(() -> {

--- a/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
+++ b/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
@@ -56,13 +56,14 @@ public class FtpUtilTest {
 
     /**
      * Invoking {@link FtpUtil#setPasv(FTPClient, boolean)} with a {@code true} value should result in the client
-     * entering passive mode.
+     * entering passive mode, and using extended passive mode.
      *
      * @throws IOException
      */
     @Test
     public void setPasvSuccess() throws IOException {
         FtpUtil.setPasv(ftpClient, true);
+        verify(ftpClient).setUseEPSVwithIPv4(true);
         verify(ftpClient).enterLocalPassiveMode();
     }
 

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -92,9 +92,6 @@
                                 <dockerFile>${project.basedir}/src/test/resources/docker/Dockerfile</dockerFile>
                             </build>
                             <run>
-                                <env>
-                                    <PUBLICHOST>${docker.host.address}</PUBLICHOST>
-                                </env>
                                 <wait>
                                     <time>6000</time>
                                 </wait>

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -28,6 +28,21 @@
     <artifactId>nihms-integration</artifactId>
     <name>Integration Tests</name>
 
+    <profiles>
+        <profile>
+            <id>external-ftp-server</id>
+            <activation>
+                <property>
+                    <name>ftp.server</name>
+                </property>
+            </activation>
+            <properties>
+                <docker.host.address>${ftp.server}</docker.host.address>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
+    </profiles>
+
     <dependencies>
 
         <dependency>

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/cli/NihmsSubmissionAppIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/cli/NihmsSubmissionAppIT.java
@@ -68,7 +68,7 @@ public class NihmsSubmissionAppIT extends BaseIT {
      */
     @Test
     public void testSubmissionFromCli() throws Exception {
-        assertFalse(ftpClient.changeWorkingDirectory(SubmissionEngine.BASE_DIRECTORY));
+        assertFalse("Did not expect working directory '" + SubmissionEngine.BASE_DIRECTORY + "' to exist!", ftpClient.changeWorkingDirectory(SubmissionEngine.BASE_DIRECTORY));
         itUtil.logout();
 
         NihmsSubmissionApp app = new NihmsSubmissionApp(new File(submissionProperties.getPath()), "local");
@@ -77,6 +77,7 @@ public class NihmsSubmissionAppIT extends BaseIT {
         itUtil.connect();
         itUtil.login();
         assertTrue(ftpClient.changeWorkingDirectory(SubmissionEngine.BASE_DIRECTORY));
+        ftpClient.setUseEPSVwithIPv4(true);
         ftpClient.enterLocalPassiveMode();
         assertEquals(1, ftpClient.listFiles().length);
     }

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/SmokeIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/SmokeIT.java
@@ -108,6 +108,7 @@ public class SmokeIT extends BaseIT {
 //        552-0 Kbytes used (0%) - authorized: 10240 Kb
 //        552 Quota exceeded: [org.jpg] won't be saved
 
+        ftpClient.setUseEPSVwithIPv4(true);
         ftpClient.enterLocalPassiveMode();
         boolean success = ftpClient.storeFile(destFile, content);
         itUtil.assertPositiveReply();
@@ -136,6 +137,7 @@ public class SmokeIT extends BaseIT {
 
         String destFile = "foo.bin";
 
+        ftpClient.setUseEPSVwithIPv4(true);
         ftpClient.enterLocalPassiveMode();
         boolean success = ftpClient.storeFile(destFile, new NullInputStream(2 ^ 20));
         itUtil.assertPositiveReply();

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportIT.java
@@ -182,6 +182,7 @@ public class FtpTransportIT extends BaseIT {
         assertErrorResponse(response);
         assertEquals(expectedException, response.error().getCause().getCause().getCause());
 
+        ftpClient.setUseEPSVwithIPv4(true);
         ftpClient.enterLocalPassiveMode();
 
         performSilently(() -> assertTrue(Stream.of(ftpClient.listFiles())
@@ -287,6 +288,7 @@ public class FtpTransportIT extends BaseIT {
      * @param expectedFilename the file that is expected to exist in the current working directory
      */
     private void assertFileListingContains(String expectedFilename) {
+        ftpClient.setUseEPSVwithIPv4(true);
         ftpClient.enterLocalPassiveMode();
 
         String prefix = (expectedFilename.contains(".")) ? expectedFilename.substring(0, expectedFilename.indexOf(".")) : expectedFilename;
@@ -308,6 +310,7 @@ public class FtpTransportIT extends BaseIT {
      * @param expectedDirectoryName the file that is expected to exist in the current working directory
      */
     private void assertDirectoryListingContains(String expectedDirectoryName) {
+        ftpClient.setUseEPSVwithIPv4(true);
         ftpClient.enterLocalPassiveMode();
 
         String prefix = (expectedDirectoryName.contains(".")) ? expectedDirectoryName.substring(0, expectedDirectoryName.indexOf(".")) : expectedDirectoryName;

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
@@ -95,6 +95,7 @@ public class FtpUtilIT extends BaseIT {
 
         assertEquals("/" + directory, ftpClient.printWorkingDirectory());
         assertTrue(ftpClient.changeToParentDirectory());
+        ftpClient.setUseEPSVwithIPv4(true);
         ftpClient.enterLocalPassiveMode();
         assertTrue(Stream.of(ftpClient.listFiles())
                 .peek(ftpFile -> LOG.debug("{}", ftpFile.getName()))

--- a/nihms-integration/src/test/resources/docker/Dockerfile
+++ b/nihms-integration/src/test/resources/docker/Dockerfile
@@ -14,4 +14,4 @@ RUN echo 'yes' > /etc/pure-ftpd/conf/VerboseLog
 
 RUN pure-pw mkdb /etc/pure-ftpd/pureftpd.pdb -f /etc/pureftpd.passwd
 
-CMD /etc/init.d/rsyslog start && /run.sh -d -d -c 1 -C 1 -H -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -P $PUBLICHOST -p 30000:30010
+CMD /etc/init.d/rsyslog start && /run.sh -d -d -c 1 -C 1 -H -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -p 30000:30010


### PR DESCRIPTION
This PR allows an external FTP server to be used in lieu of the built-in Docker FTP server when executing integration tests.

By supplying `-Dftp.server=<hostname or IP address>` to the Maven command line, a build profile will be activated in the `nihms-integration/pom.xml` that disables the Maven Docker Plugin completely, and sets the `docker.host.address` property to the value of the `ftp.server` property supplied on the command line.

All interactions with an FTP server by the integration tests in `nihms-integration` should use the defined FTP server.

`-Dftp.server=xxx.xxx.xxx.xxx` is essentially shorthand for:
`-Ddocker.skip=true -Ddocker.host.address=xxx.xxx.xxx.xxx`

