### PR TITLE
Insure IT interactions with the FTP server occur under a single, unique, directory name.

### DIFF
--- a/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSessionTest.java
+++ b/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSessionTest.java
@@ -127,23 +127,20 @@ public class FtpTransportSessionTest {
 
         when(ftpClient.printWorkingDirectory()).thenReturn(FTP_ROOT_DIR);
         when(ftpClient.changeWorkingDirectory(anyString())).thenReturn(true);
-        when(ftpClient.getReplyCode())
-                .thenReturn(FTPReply.PATHNAME_CREATED) // print working directory
-                .thenReturn(FTPReply.PATHNAME_CREATED) // print working directory
-                .thenReturn(FTPReply.COMMAND_OK) // mkd 'sub'
-                .thenReturn(FTPReply.COMMAND_OK) // cd 'sub'
-                .thenReturn(FTPReply.COMMAND_OK) // mkd 'directory'
-                .thenReturn(FTPReply.COMMAND_OK) // cd 'directory'
-                .thenReturn(FTPReply.COMMAND_OK) // cd '/'
-                .thenReturn(FTPReply.COMMAND_OK) // cd '/'
-                .thenReturn(FTPReply.COMMAND_OK) // set data type
-                .thenReturn(FTPReply.COMMAND_OK) // set pasv
-                .thenReturn(500);                // store file
-
         when(ftpClient.storeFile(anyString(), any(InputStream.class))).thenThrow(expectedException);
+        when(ftpClient.getReplyString()).thenAnswer((invocationOnMock) -> {
+            if (invocationOnMock.getMethod().getName().equals("storeFile")) {
+                return "OK";
+            }
 
-        when(ftpClient.getReplyString()).thenReturn("Transfer failed");
-
+            return "Transfer failed.";
+        });
+        when(ftpClient.getReplyCode()).thenAnswer((invocationOnMock) -> {
+            if (invocationOnMock.getMethod().getName().equals("storeFile")) {
+                return 500;
+            }
+            return 200;
+        });
 
         TransportResponse response = ftpSession.storeFile(destinationResource, content);
 

--- a/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
+++ b/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.dataconservancy.nihms.transport.ftp.FtpTestUtil.FTP_ROOT_DIR;
 import static org.dataconservancy.nihms.transport.ftp.FtpTransportHints.MODE.block;
@@ -276,11 +279,11 @@ public class FtpUtilTest {
 
         FtpUtil.makeDirectories(ftpClient, "dir");
 
-        verify(ftpClient).printWorkingDirectory();
+        verify(ftpClient, times(3)).printWorkingDirectory();
         verify(ftpClient).makeDirectory(eq("dir"));
         verify(ftpClient).changeWorkingDirectory(eq("dir"));
         verify(ftpClient).changeWorkingDirectory(FTP_ROOT_DIR);
-        verify(ftpClient, times(4)).getReplyCode();
+        verify(ftpClient, times(6)).getReplyCode();
     }
 
     /**
@@ -299,6 +302,7 @@ public class FtpUtilTest {
         when(ftpClient.makeDirectory(anyString())).thenReturn(true);
         when(ftpClient.getReplyCode())
                 .thenReturn(FTPReply.COMMAND_OK)
+                .thenReturn(FTPReply.COMMAND_OK)
                 .thenReturn(FTPReply.FILE_UNAVAILABLE)  // considered successful by FtpUtil.makeDirectories(...) because
                 // the file may already exist on the remote system
                 .thenReturn(FTPReply.FILE_UNAVAILABLE)  // Returned twice because the reply code is checked by two different callbacks
@@ -307,11 +311,11 @@ public class FtpUtilTest {
 
         FtpUtil.makeDirectories(ftpClient, "dir");
 
-        verify(ftpClient).printWorkingDirectory();
+        verify(ftpClient, times(3)).printWorkingDirectory();
         verify(ftpClient).makeDirectory(eq("dir"));
         verify(ftpClient).changeWorkingDirectory(eq("dir"));
         verify(ftpClient).changeWorkingDirectory(FTP_ROOT_DIR);
-        verify(ftpClient, times(5)).getReplyCode();
+        verify(ftpClient, times(7)).getReplyCode();
     }
 
     /**
@@ -370,7 +374,7 @@ public class FtpUtilTest {
         verify(ftpClient).changeWorkingDirectory(eq("dir"));
         verify(ftpClient).makeDirectory(eq("subdir"));
         verify(ftpClient).changeWorkingDirectory(eq("subdir"));
-        verify(ftpClient).changeWorkingDirectory(FTP_ROOT_DIR);
+        verify(ftpClient, times(2)).changeWorkingDirectory(FTP_ROOT_DIR);
         verify(ftpClient, never()).makeDirectory(eq(""));
         verify(ftpClient, never()).makeDirectory(eq(PATH_SEP));
     }
@@ -385,6 +389,7 @@ public class FtpUtilTest {
     public void testMakeDirectoryFails() throws Exception {
         when(ftpClient.printWorkingDirectory()).thenReturn(FTP_ROOT_DIR);
         when(ftpClient.getReplyCode())
+                .thenReturn(FTPReply.COMMAND_OK)
                 .thenReturn(FTPReply.COMMAND_OK)
                 .thenReturn(FTPReply.NOT_LOGGED_IN);
         when(ftpClient.makeDirectory(anyString())).thenReturn(true);

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/BaseIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/BaseIT.java
@@ -34,6 +34,12 @@ public abstract class BaseIT {
 
     protected static final String FTP_INTEGRATION_PASSWORD = "nihmsftppass";
 
+    /**
+     * A string that is likely to be unique each time ITs are run.  This string will be used as the base directory for
+     * any ITs that create content (directories, files) on the FTP server.
+     */
+    protected static final String FTP_SUBMISSION_BASE_DIRECTORY = String.format("/%s", System.currentTimeMillis());
+
     protected String ftpHost;
 
     protected int ftpPort = 21;

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/SmokeIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/SmokeIT.java
@@ -23,6 +23,8 @@ import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -40,14 +42,18 @@ import static org.junit.Assert.assertTrue;
  */
 public class SmokeIT extends BaseIT {
 
+
     /**
      * Insure the docker container started and that an ftp client can connect with the expected username
-     * and password
+     * and password.  Set the base directory to a directory that is unique to the execution of this IT.
      *
-     * @throws IOException
+     * @throws Exception
      */
-    @Test
-    public void testConnectFtpServer() throws IOException {
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        itUtil.setBaseDirectory(BaseIT.FTP_SUBMISSION_BASE_DIRECTORY);
         itUtil.connect();
         itUtil.login();
     }
@@ -60,9 +66,6 @@ public class SmokeIT extends BaseIT {
      */
     @Test
     public void testMakeDirectoryAndChangeDirectory() throws IOException {
-        itUtil.connect();
-        itUtil.login();
-
         String cwd = ftpClient.printWorkingDirectory();
 
         assertTrue(ftpClient.makeDirectory("SmokeIT-testMakeDirectoryAndChangeDirectory"));
@@ -77,9 +80,6 @@ public class SmokeIT extends BaseIT {
 
     @Test
     public void testMakeTheSameDirectoryTwice() throws Exception {
-        itUtil.connect();
-        itUtil.login();
-
         assertTrue(ftpClient.makeDirectory("SmokeIT-testMakeTheSameDirectoryTwice"));
         itUtil.assertPositiveReply();
 
@@ -93,9 +93,6 @@ public class SmokeIT extends BaseIT {
      */
     @Test
     public void testStoreFile() throws IOException, NoSuchAlgorithmException {
-        itUtil.connect();
-        itUtil.login();
-
         assertTrue(ftpClient.setFileTransferMode(FTP.STREAM_TRANSFER_MODE));
         assertTrue(ftpClient.setFileType(FTP.BINARY_FILE_TYPE));
 
@@ -129,9 +126,6 @@ public class SmokeIT extends BaseIT {
 
     @Test
     public void testStoreSameFileTwice() throws Exception {
-        itUtil.connect();
-        itUtil.login();
-
         assertTrue(ftpClient.setFileTransferMode(FTP.STREAM_TRANSFER_MODE));
         assertTrue(ftpClient.setFileType(FTP.BINARY_FILE_TYPE));
 

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportIT.java
@@ -47,6 +47,9 @@ public class FtpTransportIT extends BaseIT {
 
     private static final String FILE_LISTING = "Listing files in directory {}: {}";
 
+    private static final String FTP_BASE_DIRECTORY = String.format("%s/%s", BaseIT.FTP_SUBMISSION_BASE_DIRECTORY,
+            FtpTransportIT.class.getSimpleName());
+
     private FtpTransport transport;
 
     private FtpTransportSession transportSession;
@@ -75,12 +78,12 @@ public class FtpTransportIT extends BaseIT {
                 put(FtpTransportHints.TRANSFER_MODE, FtpTransportHints.MODE.stream.name());
 
                 // Opening a session puts us into this base directory, creating it if necessary.
-                put(FtpTransportHints.BASE_DIRECTORY, FtpTransportIT.class.getSimpleName());
+                put(FtpTransportHints.BASE_DIRECTORY, FTP_BASE_DIRECTORY);
             }
         });
 
         // Assert we were put into the correct base directory.
-        assertEquals(asDirectory(FtpTransportIT.class.getSimpleName()), ftpClient.printWorkingDirectory());
+        assertEquals(FTP_BASE_DIRECTORY, ftpClient.printWorkingDirectory());
     }
 
     /**
@@ -118,16 +121,15 @@ public class FtpTransportIT extends BaseIT {
      */
     @Test
     public void testStoreFileWithDirectory() {
-        String expectedDirectory = "FtpTransportIT";
         String expectedFilename = "testStoreFileWithDirectory.jpg";
-        String storeFilename = expectedDirectory + "/" + expectedFilename;
+        String storeFilename = String.format("%s/%s", FTP_BASE_DIRECTORY, expectedFilename);
         TransportResponse response = transportSession.storeFile(storeFilename, this.getClass().getResourceAsStream("/org.jpg"));
 
         assertSuccessfulResponse(response);
 
-        assertDirectoryListingContains(expectedDirectory);
+        assertDirectoryListingContains(FTP_BASE_DIRECTORY);
 
-        FtpUtil.setWorkingDirectory(ftpClient, expectedDirectory);
+        FtpUtil.setWorkingDirectory(ftpClient, FTP_BASE_DIRECTORY);
 
         assertFileListingContains(expectedFilename);
     }

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.util.stream.Stream;
 
+import static org.dataconservancy.nihms.integration.IntegrationUtil.directoryExists;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -35,6 +36,15 @@ public class FtpUtilIT extends BaseIT {
         super.setUp();
         FtpUtil.connect(ftpClient, ftpHost, ftpPort);
         FtpUtil.login(ftpClient, FTP_INTEGRATION_USERNAME, FTP_INTEGRATION_PASSWORD);
+
+        if (!directoryExists(ftpClient, FTP_SUBMISSION_BASE_DIRECTORY)) {
+            assertTrue("Unable to create base directory '" + FTP_SUBMISSION_BASE_DIRECTORY + "'",
+                    ftpClient.makeDirectory(FTP_SUBMISSION_BASE_DIRECTORY));
+        }
+
+        assertTrue("Unable to set working directory '" + FTP_SUBMISSION_BASE_DIRECTORY + "'",
+                ftpClient.changeWorkingDirectory(FTP_SUBMISSION_BASE_DIRECTORY));
+
     }
 
     @Override
@@ -93,7 +103,8 @@ public class FtpUtilIT extends BaseIT {
 
         FtpUtil.setWorkingDirectory(ftpClient, directory);
 
-        assertEquals("/" + directory, ftpClient.printWorkingDirectory());
+        assertEquals(String.format("%s/%s", FTP_SUBMISSION_BASE_DIRECTORY, directory),
+                ftpClient.printWorkingDirectory());
         assertTrue(ftpClient.changeToParentDirectory());
         ftpClient.setUseEPSVwithIPv4(true);
         ftpClient.enterLocalPassiveMode();

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
@@ -42,11 +42,14 @@ public class FtpUtilIT extends BaseIT {
         if (!directoryExists(ftpClient, FTP_SUBMISSION_BASE_DIRECTORY)) {
             assertTrue("Unable to create base directory '" + FTP_SUBMISSION_BASE_DIRECTORY + "'",
                     ftpClient.makeDirectory(FTP_SUBMISSION_BASE_DIRECTORY));
+            LOG.trace("Created directory: '{}'", FTP_SUBMISSION_BASE_DIRECTORY);
         }
 
         assertTrue("Unable to set working directory '" + FTP_SUBMISSION_BASE_DIRECTORY + "'",
                 ftpClient.changeWorkingDirectory(FTP_SUBMISSION_BASE_DIRECTORY));
 
+        assertEquals(FTP_SUBMISSION_BASE_DIRECTORY, ftpClient.printWorkingDirectory());
+        LOG.trace(">>> Current working directory: '{}'", ftpClient.printWorkingDirectory());
     }
 
     @Override

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
@@ -16,6 +16,7 @@
 
 package org.dataconservancy.nihms.transport.ftp;
 
+import org.apache.commons.net.ftp.FTPClient;
 import org.dataconservancy.nihms.integration.BaseIT;
 import org.junit.After;
 import org.junit.Before;
@@ -23,8 +24,9 @@ import org.junit.Test;
 
 import java.util.stream.Stream;
 
-import static org.dataconservancy.nihms.integration.IntegrationUtil.directoryExists;
+import static org.dataconservancy.nihms.transport.ftp.FtpUtil.directoryExists;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -111,5 +113,114 @@ public class FtpUtilIT extends BaseIT {
         assertTrue(Stream.of(ftpClient.listFiles())
                 .peek(ftpFile -> LOG.debug("{}", ftpFile.getName()))
                 .anyMatch(ftpFile -> ftpFile.getName().equals(directory)));
+    }
+
+    /**
+     * Test that insures {@link FtpUtil#makeDirectories(FTPClient, String)} works when the {@code directory} to be made
+     * includes intermediate directories that do not exist, and when the {@code directory} is relative to the current
+     * working directory.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMakeIntermediateDirectoriesWithRelativePaths() throws Exception {
+        String cwd = ftpClient.printWorkingDirectory();
+        String intermediateDirectory = "FtpUtilIT-testMakeIntermediateDirectoriesWithRelativePaths";
+        String absoluteIntermediateDirectory = String.format("%s/%s", cwd, intermediateDirectory);
+        String directory = String.format("%s/%s", intermediateDirectory, "subDirectory");
+        String absoluteDirectory = String.format("%s/%s", cwd, directory);
+
+        // Insure the intermediate path doesn't exist relative to the current working directory
+        assertFalse("Did not expect the intermediate directory '" + intermediateDirectory + "' to exist " +
+                        "relative to the CWD '" + cwd + "'", directoryExists(ftpClient, intermediateDirectory));
+
+        // Insure the intermediate path doesn't exist absolutely, either
+        assertFalse("Did not expect the intermediate directory '" + absoluteIntermediateDirectory + "' to " +
+                "exist relative to the CWD '" + cwd + "'", directoryExists(ftpClient, absoluteIntermediateDirectory));
+
+        // Make the directory *relative to the current working directory*
+        assertFalse("Expected directory '" + directory + "' to be relative.",
+                FtpUtil.isPathAbsolute(directory));
+        FtpUtil.makeDirectories(ftpClient, directory);
+
+        // Intermediate path ought to exist: relative to the cwd, and absolutely
+        assertTrue("Expected intermediate directory '" + intermediateDirectory + "' to exist relative to " +
+                "the CWD '" + cwd + "'", directoryExists(ftpClient, intermediateDirectory));
+        assertTrue("Expected intermediate directory '" + absoluteIntermediateDirectory + "' to exist",
+                directoryExists(ftpClient, absoluteIntermediateDirectory));
+
+        // Insure the full path exists relative to the current working directory
+        assertTrue("Expected directory '" + directory + "' to exist relative to the CWD '" + cwd + "'",
+                directoryExists(ftpClient, directory));
+
+        // Insure the full path exists absolutely
+        assertTrue("Expected directory '" + absoluteDirectory + "' to exist",
+                directoryExists(ftpClient, absoluteDirectory));
+    }
+
+    /**
+     * Test that insures {@link FtpUtil#makeDirectories(FTPClient, String)} works when the {@code directory} to be made
+     * includes intermediate directories that do not exist, and when the {@code directory} is absolute to the current
+     * working directory.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMakeIntermediateDirectoriesWithAbsolutePaths() throws Exception {
+        String cwd = ftpClient.printWorkingDirectory();
+        String intermediateDirectory = "FtpUtilIT-testMakeIntermediateDirectoriesWithAbsolutePaths";
+        String absoluteIntermediateDirectory = String.format("%s/%s", cwd, intermediateDirectory);
+        String directory = String.format("%s/%s", intermediateDirectory, "subDirectory");
+        String absoluteDirectory = String.format("%s/%s", cwd, directory);
+
+        // Insure the intermediate path doesn't exist relative to the current working directory
+        assertFalse("Did not expect the intermediate directory '" + intermediateDirectory + "' to exist " +
+                "relative to the CWD '" + cwd + "'", directoryExists(ftpClient, intermediateDirectory));
+
+        // Insure the intermediate path doesn't exist absolutely, either
+        assertFalse("Did not expect the intermediate directory '" + absoluteIntermediateDirectory + "' to " +
+                "exist relative to the CWD '" + cwd + "'", directoryExists(ftpClient, absoluteIntermediateDirectory));
+
+        // Make the directory *absolutely*, regardless of the current working directory*
+        assertTrue("Expected directory '" + absoluteDirectory + "' to be absolute.",
+                FtpUtil.isPathAbsolute(absoluteDirectory));
+        FtpUtil.makeDirectories(ftpClient, absoluteDirectory);
+
+        // Intermediate path ought to exist: relative to the cwd, and absolutely
+        assertTrue("Expected intermediate directory '" + intermediateDirectory + "' to exist relative to " +
+                "the CWD '" + cwd + "'", directoryExists(ftpClient, intermediateDirectory));
+        assertTrue("Expected intermediate directory '" + absoluteIntermediateDirectory + "' to exist",
+                directoryExists(ftpClient, absoluteIntermediateDirectory));
+
+        // Insure the full path exists relative to the current working directory
+        assertTrue("Expected directory '" + directory + "' to exist relative to the CWD '" + cwd + "'",
+                directoryExists(ftpClient, directory));
+
+        // Insure the full path exists absolutely
+        assertTrue("Expected directory '" + absoluteDirectory + "' to exist",
+                directoryExists(ftpClient, absoluteDirectory));
+
+    }
+
+    @Test
+    public void testMakeAbsoluteDestinationResourceWithDirectoryAndFilename() throws Exception {
+        String intermediateDirectory = String.format("%s/%s", FTP_SUBMISSION_BASE_DIRECTORY,
+                "testMakeAbsoluteDestinationResourceWithDirectoryAndFilename");
+        String destinationResource = String.format("%s/%s", intermediateDirectory, "foo/picture.jpg");
+
+        // Insure the intermediate path doesn't exist
+        assertFalse("Did not expect the intermediate directory '" + intermediateDirectory + "' to exist.",
+                directoryExists(ftpClient, intermediateDirectory));
+
+        // Make the directory *absolutely*, regardless of the current working directory*
+        FtpUtil.makeDirectories(ftpClient, destinationResource);
+
+        // Intermediate path ought to exist
+        assertTrue("Expected intermediate directory '" + intermediateDirectory + "' to exist",
+                directoryExists(ftpClient, intermediateDirectory));
+
+        // Insure the full path exists
+        assertTrue("Expected directory: '" + destinationResource + "' to exist.",
+                directoryExists(ftpClient, destinationResource));
     }
 }


### PR DESCRIPTION
Integration tests rely on the presence of an FTP server for testing client <-> server interactions.  When ITs execute, they will create directories and store files on the FTP server.  

At the moment, the ITs make the assumption that the FTP server state will be reset between invocations of `mvn verify` (i.e. each time the IT test suite is executed, the ITs execute against an FTP server that has no data on it to start with).  The assumption is reasonable, because the ITs execute against a fresh Docker container each time `mvn verify` is run.

This assumption is problematic when ITs are being executed against an FTP server that _does not_ have its state cleared between test suite execution; for example, an arbitrary FTP server hosted in a stable infrastructure.  This is necessary when a developer is unable to run Docker for whatever reason.

This PR updates the ITs to use unique directories by configuring a common base directory on the FTP server.  The base directory is named based on the time and date the ITs execute (to millisecond precision), so it is unlikely that this base directory will collide with another IT test execution.

The PR also contains some fixes that insure more robust test execution, including some additional JUnit assertions, code cleanup, and Javadoc.  Hopefully representing an overall improvement to IT test management and readability.