### PR TITLE
Updates the Transport API to operate with PackageStream instead of opaque InputStreams.

### DIFF
--- a/nihms-submission-engine/src/main/java/org/dataconservancy/nihms/submission/SubmissionEngine.java
+++ b/nihms-submission-engine/src/main/java/org/dataconservancy/nihms/submission/SubmissionEngine.java
@@ -27,10 +27,8 @@ import org.dataconservancy.nihms.transport.ftp.FtpTransportHints;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -102,7 +100,7 @@ public class SubmissionEngine {
      * <p>
      * This instance will be able to {@link SubmissionBuilder#build(String) build} a {@link NihmsSubmission submission
      * model}, {@link Assembler#assemble(NihmsSubmission) generate} a {@link PackageStream package}, and
-     * {@link TransportSession#send(String, InputStream) deposit} the package in a target repository.
+     * {@link TransportSession#send(PackageStream, Map) deposit} the package in a target repository.
      * </p>
      *
      * @param builder the submission model builder
@@ -145,9 +143,7 @@ public class SubmissionEngine {
         try (TransportSession session = transport.open(getTransportHints(transportHints))) {
             PackageStream stream = assembler.assemble(submission);
             resourceName = stream.metadata().name();
-            // this is using the piped input stream (returned from stream.open()).  does this have to occur in a
-            // separate thread?
-            response = session.send(resourceName, stream.open());
+            response = session.send(stream, getTransportHints(transportHints));
         } catch (Exception e) {
             throw new SubmissionFailure(format(SUBMISSION_ERROR, resourceName, e.getMessage()), e);
         }

--- a/nihms-submission-engine/src/test/java/org/dataconservancy/nihms/submission/SubmissionEngineTest.java
+++ b/nihms-submission-engine/src/test/java/org/dataconservancy/nihms/submission/SubmissionEngineTest.java
@@ -86,13 +86,13 @@ public class SubmissionEngineTest {
         when(packageStream.metadata()).thenReturn(md);
         when(md.name()).thenReturn(expectedPackageName);
         when(packageStream.open()).thenReturn(contentStream);
-        when(session.send(anyString(), any(InputStream.class))).thenReturn(response);
+        when(session.send(any(PackageStream.class), anyMap())).thenReturn(response);
         when(response.success()).thenReturn(true);
 
         engine.submit(expectedFormDataUrl);
 
         verify(builder).build(eq(expectedFormDataUrl));
-        verify(session).send(eq(expectedPackageName), eq(contentStream));
+        verify(session).send(eq(packageStream), anyMap());
         verify(response).success();
     }
 

--- a/nihms-transport-api/pom.xml
+++ b/nihms-transport-api/pom.xml
@@ -31,6 +31,12 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.dataconservancy.nihms</groupId>
+            <artifactId>nihms-assembler-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/nihms-transport-api/src/main/java/org/dataconservancy/nihms/transport/Transport.java
+++ b/nihms-transport-api/src/main/java/org/dataconservancy/nihms/transport/Transport.java
@@ -16,25 +16,52 @@
 
 package org.dataconservancy.nihms.transport;
 
+import org.dataconservancy.nihms.assembler.PackageStream;
+
 import java.util.Map;
 
 /**
- * Abstracts the transport protocol used to deposit a package with a target submission system.
+ * Abstracts the transport protocol used to deposit a package with a target submission system.  Callers are able to
+ * {@link #open(Map) open} a {@link TransportSession} by supplying configuration hints, which allows the implementation
+ * to perform necessary connection initialization, prior to a package being transported using
+ * {@link TransportSession#send(PackageStream, Map)}.
  */
 public interface Transport {
 
+    /**
+     * Property identifying the value that can be used to look up authentication credentials by reference (i.e. the
+     * value of this property serves as a key for an implementation to look up authentication credentials)
+     */
     String TRANSPORT_SERVERID = "nihms.transport.serverid";
 
+    /**
+     * Property identifying the username the implementation will use to authenticate
+     */
     String TRANSPORT_USERNAME = "nihms.transport.username";
 
+    /**
+     * Property identifying the password the implementation will use to authenticate
+     */
     String TRANSPORT_PASSWORD = "nihms.transport.password";
 
+    /**
+     * Property identifying the authentication mode.  {@link AUTHMODE} lists supported modes.
+     */
     String TRANSPORT_AUTHMODE = "nihms.transport.authmode";
 
+    /**
+     * Property identifying the transport protocol.  {@link PROTOCOL} lists supported protocols.
+     */
     String TRANSPORT_PROTOCOL = "nihms.transport.protocol";
 
+    /**
+     * Property identifying the server (or IP address) that the package will be deposited to
+     */
     String TRANSPORT_SERVER_FQDN = "nihms.transport.server-fqdn";
 
+    /**
+     * Property identifying the TCP port that will be used by the transport to deposit the package
+     */
     String TRANSPORT_SERVER_PORT = "nihms.transport.server-port";
 
     enum AUTHMODE {
@@ -63,6 +90,21 @@ public interface Transport {
         ftp
     }
 
+    /**
+     * Open a {@link TransportSession} with the underlying transport.  The returned {@code TransportSession} should be
+     * ready to use by the caller, without the caller having to perform any further setup (the implementation of this
+     * method should perform all necessary actions to allow {@link TransportSession#send(PackageStream, Map)} to
+     * succeed).  The supplied {@code hints} may be used by the implementation to configure and open the session.  Well
+     * known properties include those documented in {@link Transport}, and individual implementations may document
+     * properties as well.
+     * <p>
+     * The returned {@code TransportSession} should be {@link TransportSession#closed() open}, otherwise implementations
+     * are encouraged to throw a {@code RuntimeException} if a closed {@code TransportSession} would be returned.
+     * </p>
+     *
+     * @param hints transport implementation configuration hints
+     * @return an open {@code TransportSession}, ready to transfer packages using the underlying transport
+     */
     TransportSession open(Map<String, String> hints);
 
 }

--- a/nihms-transport-api/src/main/java/org/dataconservancy/nihms/transport/TransportSession.java
+++ b/nihms-transport-api/src/main/java/org/dataconservancy/nihms/transport/TransportSession.java
@@ -16,26 +16,37 @@
 
 package org.dataconservancy.nihms.transport;
 
-import java.io.InputStream;
-import java.util.Map;
-import java.util.concurrent.Future;
+import org.dataconservancy.nihms.assembler.PackageStream;
 
+import java.util.Map;
+
+/**
+ * Represents an open connection, or the promise of a successful connection, with a service or system that will accept
+ * the bytes of a package.  Instances of {@code TransportSession} that are immediately returned from {@link
+ * Transport#open(Map)} ought to be open (that is, {@link #closed()} should return {@code false}).  If the underlying
+ * implementation allows a {@code TransportSession} to be re-used (i.e. to {@code send(...)} multiple files), {@code
+ * closed()} can be used to check the health of the underlying connection, and whether or not this {@code
+ * TransportSession} is still viable.
+ * <p>
+ * This interface extends {@code AutoCloseable} so it can be used in a {@code try-with-resources} block.
+ * </p>
+ */
 public interface TransportSession extends AutoCloseable {
 
     /**
-     * Streams the supplied {@code content} to a destination associated with this session.  The implementation should
-     * use the supplied {@code destinationResource} to identify the submitted content in the target submission system.
-     * Implementations are responsible for creating the necessary structure on the target system to accept the
-     * {@code content} (e.g. creating a destination directory or collection in the target system that will accept the
-     * named resource).
+     * Transfer the bytes of the supplied package to the remote system.  Metadata can be optionally supplied which may
+     * help the underlying transport correctly configure itself for the transfer.
+     * <p>
+     * Note the {@code PackageStream} carries metadata about the package itself.  However, the supplied {@code metadata}
+     * could be used to <em>augment</em> the {@code PackageStream} metadata, in addition to carrying transport-related
+     * metadata.
+     * </p>
      *
-     * @param destinationResource
-     * @param content
-     * @return
+     * @param packageStream the package and package metadata
+     * @param metadata transport-related metadata, or any "extra" package metadata
+     * @return a response indicating success or failure of the transfer
      */
-    TransportResponse send(String destinationResource, InputStream content);
-
-    TransportResponse send(String destinationResource, Map<String, String> metadata, InputStream content);
+    TransportResponse send(PackageStream packageStream, Map<String, String> metadata);
 
     boolean closed();
 


### PR DESCRIPTION
Modifies the Transport API to be package-oriented instead of file oriented.  The FTP implementation didn’t really care about the form of the bytes being transported, because the transport itself doesn’t care about packaging, or packaging formats.  The SWORD implementation, however, does care, and will require access to package-level metadata.

Removes methods:
- TransportSession.send(String destinationResource, InputStream content)
- TransportResponse.send(String destinationResource, Map<String, String> metadata, InputStream content);

Replaces those methods with:
- TransportSession.send(PackageStream packageStream, Map<String, String> metadata)

Adds a dependency on the Assembler API from the Transport API

Updates the SubmissionEngine and FtpTransportSession with these changes.
Updates ITs to match.
Adds Javadoc to Transport.