### PR TITLE
Moves metadata fields from Manuscript to Article

### DIFF
--- a/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilder.java
+++ b/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilder.java
@@ -58,6 +58,7 @@ public class FilesystemModelBuilder implements SubmissionBuilder {
         NihmsMetadata metadata = new NihmsMetadata();
         NihmsMetadata.Journal journal = new NihmsMetadata.Journal();
         NihmsMetadata.Manuscript manuscript = new NihmsMetadata.Manuscript();
+        NihmsMetadata.Article article = new NihmsMetadata.Article();
         NihmsManifest manifest = new NihmsManifest();
 
         //... including the person object and its list
@@ -111,6 +112,17 @@ public class FilesystemModelBuilder implements SubmissionBuilder {
                         journal.setJournalTitle(value);
                         break;
 
+                    //article metadata
+                    case NihmsBuilderPropertyNames.NIHMS_ARTICLE_DOI:
+                        article.setDoi(URI.create(value));
+                        break;
+                    case NihmsBuilderPropertyNames.NIHMS_ARTICLE_PUBMEDCENTRALID:
+                        article.setPubmedCentralId(value);
+                        break;
+                    case NihmsBuilderPropertyNames.NIHMS_ARTICLE_PUBMEDID:
+                        article.setPubmedId(value);
+                        break;
+
                     //manuscript metadata
                     case NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_ID:
                         manuscript.setNihmsId(value);
@@ -156,6 +168,7 @@ public class FilesystemModelBuilder implements SubmissionBuilder {
 
             metadata.setJournalMetadata(journal);
             metadata.setManuscriptMetadata(manuscript);
+            metadata.setArticleMetadata(article);
 
             submission.setMetadata(metadata);
             submission.setManifest(manifest);

--- a/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilder.java
+++ b/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilder.java
@@ -112,17 +112,8 @@ public class FilesystemModelBuilder implements SubmissionBuilder {
                         break;
 
                     //manuscript metadata
-                    case NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_DOI:
-                        manuscript.setDoi(URI.create(value));                    
-                        break;
                     case NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_ID:
                         manuscript.setNihmsId(value);
-                        break;
-                    case NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_PUBMEDID:
-                        manuscript.setPubmedId(value);
-                        break;
-                    case NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_PUBMEDCENTRALID:
-                        manuscript.setPubmedCentralId(value);
                         break;
                     case NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_URL:
                         manuscript.setManuscriptUrl(new URL(value));

--- a/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/NihmsBuilderPropertyNames.java
+++ b/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/NihmsBuilderPropertyNames.java
@@ -35,14 +35,15 @@ public class NihmsBuilderPropertyNames {
     public static final String NIHMS_JOURNAL_TITLE = "nihms.journal.title";
     public static final String NIHMS_JOURNAL_PUBLICATIONTYPE = "nihms.journal.publicationtype";
 
-    public static final String NIHMS_MANUSCRIPT_DOI = "nihms.manuscript.doi";
     public static final String NIHMS_MANUSCRIPT_URL = "nihms.manuscript.url";
     public static final String NIHMS_MANUSCRIPT_ID = "nihms.manuscript.id";
-    public static final String NIHMS_MANUSCRIPT_PUBMEDCENTRALID = "nihms.manuscript.pubmedcentralid";
-    public static final String NIHMS_MANUSCRIPT_PUBMEDID = "nihms.manuscript.pubmedid";
     public static final String NIHMS_MANUSCRIPT_TITLE = "nihms.manuscript.title";
 
     public static final String NIHMS_SUBMISSION_ID = "nihms.submission.id";
     public static final String NIHMS_SUBMISSION_NAME = "nihms.submission.name";
+
+    public static final String NIHMS_ARTICLE_DOI = "nihms.article.doi";
+    public static final String NIHMS_ARTICLE_PUBMEDID = "nihms.article.pubmedid";
+    public static final String NIHMS_ARTICLE_PUBMEDCENTRALID = "nihms.article.pubmedcentralid";
 
 }

--- a/nihms-filesystem-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/nihms-filesystem-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -90,16 +90,6 @@ public class FilesystemModelBuilderTest {
         //Manuscript elements
         assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_ID),
                 submission.getMetadata().getManuscriptMetadata().getNihmsId());
-        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_PUBMEDID),
-                submission.getMetadata().getManuscriptMetadata().getPubmedId());
-        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_PUBMEDCENTRALID),
-                submission.getMetadata().getManuscriptMetadata().getPubmedCentralId());
-        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_URL),
-                submission.getMetadata().getManuscriptMetadata().getManuscriptUrl().toString());
-        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_DOI),
-                submission.getMetadata().getManuscriptMetadata().getDoi().toString());
-        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_TITLE),
-                submission.getMetadata().getManuscriptMetadata().getTitle());
     }
 
     @Test

--- a/nihms-filesystem-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/nihms-filesystem-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -90,6 +90,19 @@ public class FilesystemModelBuilderTest {
         //Manuscript elements
         assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_ID),
                 submission.getMetadata().getManuscriptMetadata().getNihmsId());
+        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_URL),
+                submission.getMetadata().getManuscriptMetadata().getManuscriptUrl().toString());
+        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_TITLE),
+                submission.getMetadata().getManuscriptMetadata().getTitle());
+
+        // Article elements
+        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_ARTICLE_PUBMEDID),
+                submission.getMetadata().getArticleMetadata().getPubmedId());
+        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_ARTICLE_PUBMEDCENTRALID),
+                submission.getMetadata().getArticleMetadata().getPubmedCentralId());
+        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_ARTICLE_DOI),
+                submission.getMetadata().getArticleMetadata().getDoi().toString());
+
     }
 
     @Test

--- a/nihms-filesystem-builder/src/test/resources/FilesystemModelBuilderTest.properties
+++ b/nihms-filesystem-builder/src/test/resources/FilesystemModelBuilderTest.properties
@@ -31,11 +31,12 @@ nihms.journal.issn = 1234-5678
 nihms.journal.id = FJ001
 nihms.journal.title = Cows and their Importance to Humanity
 
-nihms.manuscript.doi = doi:10.1234/smh0000001
+nihms.article.doi = doi:10.1234/smh0000001
+nihms.article.pubmedcentralid = PMC0000001
+nihms.article.pubmedid = 0000001
+
 nihms.manuscript.url = http://farm.com.Cows
 nihms.manuscript.id = cow1
-nihms.manuscript.pubmedcentralid = PMC0000001
-nihms.manuscript.pubmedid = 0000001
 nihms.manuscript.title = A Treatise On Clover
 
 nihms.submission.id = 1

--- a/nihms-model/src/main/java/org/dataconservancy/nihms/model/NihmsMetadata.java
+++ b/nihms-model/src/main/java/org/dataconservancy/nihms/model/NihmsMetadata.java
@@ -72,26 +72,9 @@ public class NihmsMetadata {
         public String nihmsId;
 
         /**
-         * PubMed ID, if known.
-         * TODO: figure out where PMID comes from, and its significance to NIHMS; difference from {@link #pubmedCentralId}
-         */
-        public String pubmedId;
-
-        /**
-         * PubMed Central ID, if known.
-         * TODO: figure out where id comes from, and its significance to NIHMS; difference from {@link #pubmedId}
-         */
-        public String pubmedCentralId;
-
-        /**
-         * URL to the final version of the article, if known.
+         * URL to the manuscript, if known.
          */
         public URL manuscriptUrl;
-
-        /**
-         * DOI for the final version of the article, if known.
-         */
-        public URI doi;
 
         /**
          * {@code true} if the submission includes the the publisher's final PDF version of the manuscript
@@ -99,17 +82,34 @@ public class NihmsMetadata {
         public boolean publisherPdf;
 
         /**
-         * {@code true} if {@link #publisherPdf} is {@code true} <em>and</em> if the publisher's final PDF version should be
-         * used in lieu of the NIHMS-generated PDF in PubMed Central.
+         * {@code true} if {@link #publisherPdf} is {@code true} <em>and</em> if the publisher's final PDF version
+         * should be used in lieu of the NIHMS-generated PDF in PubMed Central.
          */
         public boolean showPublisherPdf;
 
         /**
-         * The interval between a manuscript's final publication date and when the NIHMS manuscript will appear publicly in PubMed Central
+         * The interval between a manuscript's final publication date and when the NIHMS manuscript will appear publicly
+         * in PubMed Central
          */
         public int relativeEmbargoPeriodMonths;
 
+        /**
+         * The title of the manuscript
+         */
         public String title;
+
+        /**
+         * A brief abstract of the manuscript
+         */
+        public String msAbstract;
+
+        public String getMsAbstract() {
+            return msAbstract;
+        }
+
+        public void setMsAbstract(String msAbstract) {
+            this.msAbstract = msAbstract;
+        }
 
         public String getTitle() { return title; }
 
@@ -123,36 +123,12 @@ public class NihmsMetadata {
             this.nihmsId = nihmsId;
         }
 
-        public String getPubmedId() {
-            return pubmedId;
-        }
-
-        public void setPubmedId(String pubmedId) {
-            this.pubmedId = pubmedId;
-        }
-
-        public String getPubmedCentralId() {
-            return pubmedCentralId;
-        }
-
-        public void setPubmedCentralId(String pubmedCentralId) {
-            this.pubmedCentralId = pubmedCentralId;
-        }
-
         public URL getManuscriptUrl() {
             return manuscriptUrl;
         }
 
         public void setManuscriptUrl(URL manuscriptUrl) {
             this.manuscriptUrl = manuscriptUrl;
-        }
-
-        public URI getDoi() {
-            return doi;
-        }
-
-        public void setDoi(URI doi) {
-            this.doi = doi;
         }
 
         public boolean isPublisherPdf() {
@@ -249,7 +225,55 @@ public class NihmsMetadata {
 
     // TODO: filled in by submitter or for NIHMS?
     public static class Article {
+        /**
+         * PubMed ID, if known.
+         * TODO: figure out where PMID comes from, and its significance to NIHMS; difference from {@link #pubmedCentralId}
+         */
+        public String pubmedId;
 
+        /**
+         * PubMed Central ID, if known.
+         * TODO: figure out where id comes from, and its significance to NIHMS; difference from {@link #pubmedId}
+         */
+        public String pubmedCentralId;
+
+        /**
+         * DOI for the final version of the article, if known.
+         */
+        public URI doi;
+
+        /**
+         * The title of the article
+         */
+        public String title;
+
+        public String getTitle() { return title; }
+
+        public void setTitle(String title) { this.title = title; }
+
+        public String getPubmedId() {
+            return pubmedId;
+        }
+
+        public void setPubmedId(String pubmedId) {
+            this.pubmedId = pubmedId;
+        }
+
+        public String getPubmedCentralId() {
+            return pubmedCentralId;
+        }
+
+        public void setPubmedCentralId(String pubmedCentralId) {
+            this.pubmedCentralId = pubmedCentralId;
+        }
+
+        public URI getDoi() {
+            return doi;
+        }
+
+        public void setDoi(URI doi) {
+            this.doi = doi;
+        }
     }
 
     /**

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
@@ -84,19 +84,6 @@ public class NihmsMetadataSerializer implements StreamingSerializer{
             writer.addAttribute("show_publisher_pdf", booleanConvert(manuscript.isShowPublisherPdf()));
             writer.addAttribute("embargo", String.valueOf(manuscript.getRelativeEmbargoPeriodMonths()));
 
-            if(manuscript.getPubmedId() != null){
-                writer.addAttribute("pmid", manuscript.getPubmedId());
-            }
-
-            if(manuscript.getPubmedCentralId() != null){
-                writer.addAttribute("pmcid", manuscript.getPubmedCentralId());
-            }
-            if(manuscript.getManuscriptUrl() != null){
-                writer.addAttribute("href", manuscript.getManuscriptUrl().toString());
-            }
-            if(manuscript.getDoi() != null){
-                writer.addAttribute("doi", manuscript.getDoi().toString());
-            }
             writer.endNode(); //end manuscript
 
             //process journal

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
@@ -74,6 +74,7 @@ public class NihmsMetadataSerializer implements StreamingSerializer{
 
             //process manuscript element (except, strangely, for title, which we do after journal)
             NihmsMetadata.Manuscript manuscript = metadata.getManuscriptMetadata();
+            NihmsMetadata.Article article = metadata.getArticleMetadata();
             writer.startNode("manuscript");
             if(manuscript.getNihmsId() != null) {
                 writer.addAttribute("id", manuscript.getNihmsId());
@@ -83,6 +84,20 @@ public class NihmsMetadataSerializer implements StreamingSerializer{
             writer.addAttribute("publisher_pdf", booleanConvert(manuscript.isPublisherPdf()));
             writer.addAttribute("show_publisher_pdf", booleanConvert(manuscript.isShowPublisherPdf()));
             writer.addAttribute("embargo", String.valueOf(manuscript.getRelativeEmbargoPeriodMonths()));
+
+            if (article.getPubmedId() != null) {
+                writer.addAttribute("pmid", article.getPubmedId());
+            }
+
+            if (article.getPubmedCentralId() != null) {
+                writer.addAttribute("pmcid", article.getPubmedCentralId());
+            }
+            if (manuscript.getManuscriptUrl() != null) {
+                writer.addAttribute("href", manuscript.getManuscriptUrl().toString());
+            }
+            if (article.getDoi() != null) {
+                writer.addAttribute("doi", article.getDoi().toString());
+            }
 
             writer.endNode(); //end manuscript
 

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
@@ -59,12 +59,9 @@ public class NihmsMetadataSerializerTest {
         journal.setPubType(NihmsMetadata.JOURNAL_PUBLICATION_TYPE.epub);
 
         //populate manuscript metadata
-        manuscript.setDoi(URI.create("doi:10.1234/smh0000001"));
         manuscript.setManuscriptUrl(new URL("http://farm.com/Cows"));
         manuscript.setNihmsId("00001");
         manuscript.setPublisherPdf(true);
-        manuscript.setPubmedCentralId("PMC00001");
-        manuscript.setPubmedId("00001");
         manuscript.setRelativeEmbargoPeriodMonths(0);
         manuscript.setShowPublisherPdf(false);
         manuscript.setTitle("Manuscript Title");

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
@@ -50,6 +50,7 @@ public class NihmsMetadataSerializerTest {
         //set up metadata snd its fields;
         NihmsMetadata.Journal journal = new NihmsMetadata.Journal();
         NihmsMetadata.Manuscript manuscript = new NihmsMetadata.Manuscript();
+        NihmsMetadata.Article article = new NihmsMetadata.Article();
         List<NihmsMetadata.Person> personList = new ArrayList<>();
 
         //populate journal metadata
@@ -65,6 +66,11 @@ public class NihmsMetadataSerializerTest {
         manuscript.setRelativeEmbargoPeriodMonths(0);
         manuscript.setShowPublisherPdf(false);
         manuscript.setTitle("Manuscript Title");
+
+        // populate article metadata
+        article.setDoi(URI.create("doi:10.1234/smh0000001"));
+        article.setPubmedCentralId("PMC00001");
+        article.setPubmedId("00001");
 
         //populate persons
         NihmsMetadata.Person person1 = new NihmsMetadata.Person();
@@ -110,6 +116,7 @@ public class NihmsMetadataSerializerTest {
         metadata.setJournalMetadata(journal);
         metadata.setManuscriptMetadata(manuscript);
         metadata.setPersons(personList);
+        metadata.setArticleMetadata(article);
 
         underTest = new NihmsMetadataSerializer(metadata);
     }


### PR DESCRIPTION
Moves identifiers for the article from the `Manuscript` to the `Article`.
Adds `abstract` field to the `Manuscript`.
Updates serializers and tests.