### PR TITLE
Adds embargo metadata to the Article

### DIFF
--- a/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositMetadata.java
+++ b/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositMetadata.java
@@ -89,12 +89,6 @@ public class DepositMetadata {
         public boolean showPublisherPdf;
 
         /**
-         * The interval between a manuscript's final publication date and when the manuscript will appear publicly
-         * in PubMed Central
-         */
-        public int relativeEmbargoPeriodMonths;
-
-        /**
          * The title of the manuscript
          */
         public String title;
@@ -148,13 +142,6 @@ public class DepositMetadata {
             this.showPublisherPdf = showPublisherPdf;
         }
 
-        public int getRelativeEmbargoPeriodMonths() {
-            return relativeEmbargoPeriodMonths;
-        }
-
-        public void setRelativeEmbargoPeriodMonths(int relativeEmbargoPeriodMonths) {
-            this.relativeEmbargoPeriodMonths = relativeEmbargoPeriodMonths;
-        }
     }
 
     /**

--- a/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositMetadata.java
+++ b/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositMetadata.java
@@ -18,6 +18,7 @@ package org.dataconservancy.nihms.model;
 
 import java.net.URI;
 import java.net.URL;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -247,6 +248,8 @@ public class DepositMetadata {
          */
         public String title;
 
+        public ZonedDateTime embargoLiftDate;
+
         public String getTitle() { return title; }
 
         public void setTitle(String title) { this.title = title; }
@@ -273,6 +276,14 @@ public class DepositMetadata {
 
         public void setDoi(URI doi) {
             this.doi = doi;
+        }
+
+        public ZonedDateTime getEmbargoLiftDate() {
+            return embargoLiftDate;
+        }
+
+        public void setEmbargoLiftDate(ZonedDateTime embargoLiftDate) {
+            this.embargoLiftDate = embargoLiftDate;
         }
     }
 

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
@@ -83,6 +83,9 @@ public class NihmsMetadataSerializer implements StreamingSerializer{
             //primitive types
             writer.addAttribute("publisher_pdf", booleanConvert(manuscript.isPublisherPdf()));
             writer.addAttribute("show_publisher_pdf", booleanConvert(manuscript.isShowPublisherPdf()));
+            if (metadata.getArticleMetadata() != null && metadata.getArticleMetadata().getEmbargoLiftDate() != null) {
+                // TODO: resolve the calculation of the embargo offset
+            }
 
             if (article.getPubmedId() != null) {
                 writer.addAttribute("pmid", article.getPubmedId());

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
@@ -83,7 +83,6 @@ public class NihmsMetadataSerializer implements StreamingSerializer{
             //primitive types
             writer.addAttribute("publisher_pdf", booleanConvert(manuscript.isPublisherPdf()));
             writer.addAttribute("show_publisher_pdf", booleanConvert(manuscript.isShowPublisherPdf()));
-            writer.addAttribute("embargo", String.valueOf(manuscript.getRelativeEmbargoPeriodMonths()));
 
             if (article.getPubmedId() != null) {
                 writer.addAttribute("pmid", article.getPubmedId());

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
@@ -63,7 +63,6 @@ public class NihmsMetadataSerializerTest {
         manuscript.setManuscriptUrl(new URL("http://farm.com/Cows"));
         manuscript.setNihmsId("00001");
         manuscript.setPublisherPdf(true);
-        manuscript.setRelativeEmbargoPeriodMonths(0);
         manuscript.setShowPublisherPdf(false);
         manuscript.setTitle("Manuscript Title");
 


### PR DESCRIPTION
Updates `DepositMetadata.Article` to carry the embargo date, and removes it from the `DepositMetadata.Manuscript`.