### PR TITLE
Handle exceptions occurring in the Thread creating the PackageStream

### DIFF
--- a/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsPackageStreamIT.java
+++ b/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsPackageStreamIT.java
@@ -19,6 +19,7 @@ package org.dataconservancy.pass.deposit.assembler.dspace.mets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.dataconservancy.nihms.assembler.MetadataBuilder;
+import org.dataconservancy.nihms.model.DepositFileType;
 import org.dataconservancy.pass.deposit.assembler.shared.DefaultResourceBuilderFactory;
 import org.dataconservancy.pass.deposit.assembler.shared.MetadataBuilderImpl;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
@@ -34,8 +35,10 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
+import static org.dataconservancy.pass.deposit.assembler.dspace.mets.DepositTestUtil.composeSubmission;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -68,9 +71,18 @@ public class DspaceMetsPackageStreamIT {
 
     @Test
     public void testStream() throws Exception {
+
+        DepositSubmission submission = composeSubmission(this.getClass().getName() + "_testStream",
+                new HashMap<File, DepositFileType>() {
+                    {
+                        put(custodialContent.get(0).getFile(), DepositFileType.manuscript);
+                        put(custodialContent.get(1).getFile(), DepositFileType.supplement);
+                    }
+
+                });
         // Construct a package stream using mocks and two example files
         DspaceMetsZippedPackageStream underTest =
-                new DspaceMetsZippedPackageStream(mock(DepositSubmission.class), custodialContent, mb, rbf, metsWriter);
+                new DspaceMetsZippedPackageStream(submission, custodialContent, mb, rbf, metsWriter);
 
         File outFile = new File(tempDir, "testStream.tar.gz");
         FileOutputStream out = new FileOutputStream(outFile);

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
@@ -46,7 +46,10 @@ public class NihmsAssembler extends AbstractAssembler {
 
     @Override
     protected PackageStream createPackageStream(DepositSubmission submission, List<Resource> custodialResources, MetadataBuilder mb, ResourceBuilderFactory rbf) {
-        return new NihmsZippedPackageStream(submission, custodialResources, mb, rbf);
+        NihmsZippedPackageStream stream = new NihmsZippedPackageStream(submission, custodialResources, mb, rbf);
+        stream.setManifestSerializer(new NihmsManifestSerializer(submission.getManifest()));
+        stream.setMetadataSerializer(new NihmsMetadataSerializer(submission.getMetadata()));
+        return stream;
     }
 
 }

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/ExHandingPipedInputStream.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/ExHandingPipedInputStream.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.assembler.shared;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+/**
+ * Re-throws the {@code Throwable} set by {@link #setWriterEx(Throwable)} when any {@code public} or {@code protected}
+ * method of {@link PipedInputStream} is invoked.
+ * <p>
+ * Upon invocation of any {@code public} or {@code protected} methods of {@code PipedInputStream}, the presence of a
+ * {@link Throwable} (stored in a member {@code volatile} variable) is checked.  If a {@code Throwable} is present, it
+ * indicates that the <em>writing</em> side of the pipe encountered an exception.  The writer is executing in a
+ * separate thread, and cannot report exceptions "up the stack" to the caller.  Instead, the writer (via a {@link
+ * Thread.UncaughtExceptionHandler}) sets any caught exceptions on the <em>reading</em> side of the pipe, and the
+ * reading side of the pipe will re-throw them to readers if {@link #setWriterEx(Throwable)} is called with a non-{@code
+ * null Throwable}.
+ * </p>
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class ExHandingPipedInputStream extends PipedInputStream {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExHandingPipedInputStream.class);
+
+    /**
+     * If non-null, represents an exception that was thrown on the <em>writing</em> side of the pipe.  It should be
+     * re-thrown to callers of {@link PipedInputStream} {@code public} or {@code protected} methods.
+     */
+    private volatile Throwable writerEx;
+
+    public ExHandingPipedInputStream(int pipeSize) {
+        super(pipeSize);
+    }
+
+    @Override
+    public void connect(PipedOutputStream src) throws IOException {
+        handleEx();
+        super.connect(src);
+    }
+
+    @Override
+    protected synchronized void receive(int b) throws IOException {
+        handleEx();
+        super.receive(b);
+    }
+
+    @Override
+    public synchronized int read() throws IOException {
+        handleEx();
+        return super.read();
+    }
+
+    @Override
+    public synchronized int read(byte[] b, int off, int len) throws IOException {
+        handleEx();
+        return super.read(b, off, len);
+    }
+
+    @Override
+    public synchronized int available() throws IOException {
+        handleEx();
+        return super.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Close the stream, regardless of whether or not there is an exception waiting for us
+        try {
+            super.close();
+        } finally {
+            handleEx();
+        }
+    }
+
+    /**
+     * Obtain the {@code Throwable} that presumably occurred on the <em>writing</em> side of this pipe.  It will be re-
+     * thrown as an {@link IOException} the next time a {@code public} or {@code protected} method of {@link
+     * PipedInputStream} is invoked.
+     *
+     * @return a {@code Throwable} that occurred while writing to the pipe, or {@code null} if no exception has occurred
+     */
+    public Throwable getWriterEx() {
+        return writerEx;
+    }
+
+    /**
+     * Set the {@code Throwable} that presumably occurred on the <em>writing</em> side of this pipe.  It will be re-
+     * thrown as an {@link IOException} the next time a {@code public} or {@code protected} method of {@link
+     * PipedInputStream} is invoked.
+     *
+     * @param writerEx a {@code Throwable} that occurred while writing to the pipe
+     */
+    public void setWriterEx(Throwable writerEx) {
+        this.writerEx = writerEx;
+    }
+
+    /**
+     * Checks for a non-null {@link #writerEx}, and re-throws it as an {@link IOException}.
+     *
+     * @throws IOException the wrapped {@link #writerEx}
+     */
+    private void handleEx() throws IOException {
+        if (writerEx == null) {
+            return;
+        }
+
+        LOG.error("The writing side of this PipedInputStream encountered an exception: {}",
+                writerEx.getMessage(), writerEx);
+
+        throw new IOException("The writing side of this PipedInputStream encountered an exception: " +
+                writerEx.getMessage(), writerEx);
+    }
+}


### PR DESCRIPTION
Addresses #16, where exceptions that occur when writing the `PackageStream` are ignored.  Writers will unwittingly read from the stream until it is closed, not realizing that the stream is most likely corrupt.

* Subclasses `PipedInputStream`, which checks a member variable that references a `Throwable`; if the `Throwable` isn't `null`, it is re-thrown when any `public` or `protected` method of `PipedInputStream` is invoked.
    * The member `Throwable` is populated/set by an exception handler that monitors the _writing_ side of the stream.
    * If the handler catches an exception from the writing side, it sets it on the sub-classed `PipedInputStream` described above
    * In this way, exceptions occurring on the _writing_ side are seen by the _reading_ side, and the reader knows that the stream is most likely corrupted

* Fixes a bug in the `NihmsAssembler` revealed by this fix