### PR TITLE
Add Fedora server to integration suite and include fedora-related ITs

### DIFF
--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/PassJsonFedoraAdapter.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/PassJsonFedoraAdapter.java
@@ -58,7 +58,7 @@ import java.util.List;
  *
  * @author Ben Trumbore (wbt3@cornell.edu)
  */
-class PassJsonFedoraAdapter {
+public class PassJsonFedoraAdapter {
 
     /**
      * Extract PassEntity data from a JSON input stream and fill a collection of PassEntity objects.
@@ -66,7 +66,7 @@ class PassJsonFedoraAdapter {
      * @param entities the map that will contain the parsed PassEntity objects, indexed by their IDs.
      * @return the PassEntity Submission object that is the root of the data tree.
      */
-    Submission jsonToPass(InputStream is, HashMap<URI, PassEntity> entities) {
+    public Submission jsonToPass(InputStream is, HashMap<URI, PassEntity> entities) {
         Submission submission = null;
         try {
             // Read JSON stream that defines the sample repo data
@@ -116,7 +116,7 @@ class PassJsonFedoraAdapter {
      * @param entities the map that contains the PassEntity objects to serialize.
      * @param os the output stream carrying the JSON representing the PassEntity objects.
      */
-    void passToJson(HashMap<URI, PassEntity> entities, OutputStream os) {
+    public void passToJson(HashMap<URI, PassEntity> entities, OutputStream os) {
         PassJsonAdapterBasic adapter = new PassJsonAdapterBasic();
         ArrayList<URI> printedUris = new ArrayList<>();
         PrintWriter pw = new PrintWriter(os);
@@ -167,7 +167,7 @@ class PassJsonFedoraAdapter {
      * @param entities the PassEntity objects to upload.
      * @return the URI on the Fedora server of the newly created Submission resource.
      */
-    URI passToFcrepo(HashMap<URI, PassEntity> entities) {
+    public URI passToFcrepo(HashMap<URI, PassEntity> entities) {
         PassClient client = PassClientFactory.getPassClient();
         HashMap<URI, URI> uriMap = new HashMap<>();
         URI submissionUri = null;
@@ -250,7 +250,7 @@ class PassJsonFedoraAdapter {
      * @param entities the collection of PassEntity objects that is created.
      * @return the Submission entity that corresponds to the provided URI.
      */
-    Submission fcrepoToPass(URI submissionUri, HashMap<URI, PassEntity> entities) {
+    public Submission fcrepoToPass(URI submissionUri, HashMap<URI, PassEntity> entities) {
         PassClient client = PassClientFactory.getPassClient();
 
         Submission submission = client.readResource(submissionUri, Submission.class);
@@ -306,7 +306,7 @@ class PassJsonFedoraAdapter {
      * @param is the stream containing the JSON data.
      * @return the RUI of the root Submission resource on the Fedora server.
      */
-    URI jsonToFcrepo(InputStream is) {
+    public URI jsonToFcrepo(InputStream is) {
         HashMap<URI, PassEntity> entities = new HashMap<>();
         jsonToPass(is, entities);
         return passToFcrepo(entities);
@@ -322,7 +322,7 @@ class PassJsonFedoraAdapter {
      * @param submissionUri the URI for the root Submission resource to download.
      * @param os the output stream containing the serialized data.
      */
-    void fcrepoToJson(URI submissionUri, OutputStream os) {
+    public void fcrepoToJson(URI submissionUri, OutputStream os) {
         HashMap<URI, PassEntity> entities = new HashMap<>();
         fcrepoToPass(submissionUri, entities);
         passToJson(entities, os);

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -32,6 +32,11 @@
         <ftp.skip>false</ftp.skip>
         <dspace.skip>false</dspace.skip>
         <postgres.skip>false</postgres.skip>
+        <fcrepo.skip>false</fcrepo.skip>
+        <fcrepo.server>${docker.host.address}</fcrepo.server>
+        <pass.fedora.user>admin</pass.fedora.user>
+        <pass.fedora.password>moo</pass.fedora.password>
+        <pass.fedora.baseurl>http://${docker.host.address}:${fcrepo.http.port}/fcrepo/rest/</pass.fedora.baseurl>
     </properties>
 
 
@@ -59,6 +64,18 @@
                 <docker.host.address>${dspace.server}</docker.host.address>
                 <dspace.skip>true</dspace.skip>
                 <postgres.skip>true</postgres.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>external-fcrepo-server</id>
+            <activation>
+                <property>
+                    <name>fcrepo.server</name>
+                </property>
+            </activation>
+            <properties>
+                <fcrepo.skip>true</fcrepo.skip>
+                <pass.fedora.baseurl>http://${fcrepo.server}:${fcrepo.http.port}/fcrepo/rest/</pass.fedora.baseurl>
             </properties>
         </profile>
     </profiles>
@@ -121,6 +138,27 @@
     <build>
 
         <plugins>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>reserve-network-port</id>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <portNames>
+                                <portName>fcrepo.http.port</portName>
+                                <portName>fcrepo.jms.port</portName>
+                                <portName>fcrepo.stomp.port</portName>
+                            </portNames>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>io.fabric8</groupId>
@@ -187,6 +225,32 @@
                                 </env>
                             </run>
                         </image>
+                        <image>
+                            <alias>fcrepo</alias>
+                            <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT</name>
+                            <run>
+                                <skip>${fcrepo.skip}</skip>
+                                <wait>
+                                    <!-- Should use ${pass.fedora.baseurl}, but need to add authentication params to the URL -->
+                                    <url>http://${pass.fedora.user}:${pass.fedora.password}@${fcrepo.server}:${fcrepo.http.port}/fcrepo/rest/</url>
+                                    <time>180000</time>
+                                </wait>
+                                <ports>
+                                    <port>${fcrepo.http.port}:${fcrepo.http.port}</port>
+                                    <port>${fcrepo.jms.port}:${fcrepo.jms.port}</port>
+                                    <port>${fcrepo.stomp.port}:${fcrepo.stomp.port}</port>
+                                </ports>
+                                <env>
+                                    <FCREPO_HOST>fcrepo</FCREPO_HOST>
+                                    <FCREPO_PORT>${fcrepo.http.port}</FCREPO_PORT>
+                                    <FCREPO_JMS_PORT>${fcrepo.jms.port}</FCREPO_JMS_PORT>
+                                    <FCREPO_STOMP_PORT>${fcrepo.stomp.port}</FCREPO_STOMP_PORT>
+                                    <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
+                                    <FCREPO_JMS_BASEURL>${pass.fedora.baseurl}</FCREPO_JMS_BASEURL>
+                                    <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld</COMPACTION_URI>
+                                </env>
+                            </run>
+                        </image>
                     </images>
                 </configuration>
                 <executions>
@@ -215,6 +279,9 @@
                     <systemProperties>
                         <docker.host.address>${docker.host.address}</docker.host.address>
                         <LOCAL_FTP_SERVER>${docker.host.address}</LOCAL_FTP_SERVER>
+                        <pass.fedora.user>${pass.fedora.user}</pass.fedora.user>
+                        <pass.fedora.password>${pass.fedora.password}</pass.fedora.password>
+                        <pass.fedora.baseurl>${pass.fedora.baseurl}</pass.fedora.baseurl>
                     </systemProperties>
                 </configuration>
                 <executions>

--- a/nihms-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package org.dataconservancy.nihms.builder.fs;
+package org.dataconservancy.pass.deposit.builder.fedora;
 
+import org.dataconservancy.nihms.builder.fs.FcrepoModelBuilder;
+import org.dataconservancy.nihms.builder.fs.PassJsonFedoraAdapter;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -36,7 +38,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
 
-public class FcrepoModelBuilderTest {
+public class FcrepoModelBuilderIT {
 
     private DepositSubmission submission;
     private FcrepoModelBuilder underTest = new FcrepoModelBuilder();
@@ -46,21 +48,20 @@ public class FcrepoModelBuilderTest {
     public void setup() throws Exception {
         // Upload sample data to Fedora repository to get its URI.
         PassJsonFedoraAdapter reader = new PassJsonFedoraAdapter();
-        URL sampleDataUrl = FcrepoModelBuilderTest.class.getClassLoader().getResource(SAMPLE_SUBMISSION_RESOURCE);
+        URL sampleDataUrl = this.getClass().getResource(SAMPLE_SUBMISSION_RESOURCE);
         InputStream is = new FileInputStream(sampleDataUrl.getPath());
         URI submissionUri = reader.jsonToFcrepo(is);
         is.close();
         submission = underTest.build(submissionUri.toString());
     }
 
-    //@Test
+    @Test
     public void testElementValues() {
         // Load the PassEntity version of the sample data file
         Submission submissionEntity = null;
         HashMap<URI, PassEntity> entities = new HashMap<>();
         try {
-            URL sampleDataUrl =
-                    FilesystemModelBuilderTest.class.getClassLoader().getResource(SAMPLE_SUBMISSION_RESOURCE);
+            URL sampleDataUrl = this.getClass().getResource(SAMPLE_SUBMISSION_RESOURCE);
             InputStream is = new FileInputStream(sampleDataUrl.getPath());
             PassJsonFedoraAdapter reader = new PassJsonFedoraAdapter();
             submissionEntity = reader.jsonToPass(is, entities);

--- a/nihms-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/PassJsonFedoraAdapterIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/PassJsonFedoraAdapterIT.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package org.dataconservancy.nihms.builder.fs;
+package org.dataconservancy.pass.deposit.builder.fedora;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.commons.io.IOUtils;
+import org.dataconservancy.nihms.builder.fs.PassJsonFedoraAdapter;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class PassJsonFedoraAdapterTest {
+public class PassJsonFedoraAdapterIT {
 
     private String SAMPLE_DATA_FILE = "SampleSubmissionData.json";
     private URL sampleDataUrl;
@@ -45,11 +46,11 @@ public class PassJsonFedoraAdapterTest {
 
     @Before
     public void setup() {
-        sampleDataUrl = FilesystemModelBuilderTest.class.getClassLoader().getResource(SAMPLE_DATA_FILE);
+        sampleDataUrl = this.getClass().getResource(SAMPLE_DATA_FILE);
         reader = new PassJsonFedoraAdapter();
     }
 
-    //@Test
+    @Test
     public void roundTrip() {
         try {
             // Upload the sample data to the Fedora repo.

--- a/nihms-integration/src/test/resources/org/dataconservancy/pass/deposit/builder/fedora/SampleSubmissionData.json
+++ b/nihms-integration/src/test/resources/org/dataconservancy/pass/deposit/builder/fedora/SampleSubmissionData.json
@@ -1,0 +1,135 @@
+[
+  {
+    "metadata" : "[]",
+    "source" : "pass",
+    "submitted" : true,
+    "submittedDate" : "2017-06-02T00:00:00.000Z",
+    "aggregatedDepositStatus" : "not-started",
+    "publication" : "fake:publication1",
+    "repositories" : [ "fake:repository1" ],
+    "user" : "fake:user1",
+    "grants" : [ "fake:grant1" ],
+    "@id" : "fake:submission1",
+    "@type" : "Submission"
+  },
+  {
+    "title" : "This is the first submission",
+    "abstract" : "This is a great paper!",
+    "doi" : "abcdef",
+    "pmid" : "fedcba",
+    "journal" : "fake:journal1",
+    "volume" : "123",
+    "issue" : "May 2015",
+    "@id" : "fake:publication1",
+    "@type" : "Publication"
+  },
+  {
+    "name" : "AAPS PharmSci",
+    "issns" : [ "issn123", "issn456" ],
+    "nlmta" : "AAPS PharmSci",
+    "pmcParticipation" : "A",
+    "publisher" : "fake:publisher1",
+    "@id" : "fake:journal1",
+    "@type" : "Journal"
+  },
+  {
+    "name" : "American Association of Pharmaceutical Scientists",
+    "pmcParticipation" : "A",
+    "@id" : "fake:publisher1",
+    "@type" : "Publisher"
+  },
+  {
+    "name" : "PubMed Central",
+    "description" : "Contains lots of medical papers",
+    "url" : "http://example.com",
+    "formSchema" : "{}",
+    "@id" : "fake:repository1",
+    "@type" : "Repository"
+  },
+  {
+    "awardNumber" : "R01EY026617",
+    "awardStatus" : "active",
+    "localKey" : "112233",
+    "projectName" : "Optimal magnification and oculomotor strategies in low vision patients",
+    "awardDate" : "2017-06-01T00:00:00.000Z",
+    "startDate" : "2017-05-01T00:00:00.000Z",
+    "endDate" : "2018-06-01T00:00:00.000Z",
+    "primaryFunder" : "fake:funder1",
+    "directFunder" : "fake:funder2",
+    "pi" : "fake:user2",
+    "coPis" : [ "fake:user3" ],
+    "@id" : "fake:grant1",
+    "@type" : "Grant"
+  },
+  {
+    "name" : "National Eye Institute",
+    "url" : "http://example.com/eyeguys",
+    "localKey" : "aabbcc",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder1",
+    "@type" : "Funder"
+  },
+  {
+    "title" : "Be Nice to People With Eyes",
+    "description" : "We only have eyes for you.",
+    "policyUrl" : "http://theeyeshaveit.com/policy",
+    "repositories" : [ "fake:repository1" ],
+    "institution" : "fake:institution1",
+    "funder" : "fake:funder1",
+    "@id" : "fake:policy1",
+    "@type" : "Policy"
+  },
+  {
+    "name" : "International Eye Institute",
+    "url" : "http://example.com/othereyeguys",
+    "localKey" : "ddeeff",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder2",
+    "@type" : "Funder"
+  },
+  {
+    "username" : "bobsmith",
+    "firstName" : "Robert",
+    "middleName" : "Cure",
+    "lastName" : "Smith",
+    "displayName" : "Bob Smith",
+    "email" : "bobsmith@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "bs1",
+    "localKey" : "key123",
+    "orcidId" : "orcid123",
+    "roles" : [ "submitter", "admin" ],
+    "@id" : "fake:user1",
+    "@type" : "User"
+  },
+  {
+    "username" : "suzyv",
+    "firstName" : "Suzanne",
+    "middleName" : "X",
+    "lastName" : "Vega",
+    "displayName" : "Suzanne Vega",
+    "email" : "suzannev@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "sxv3",
+    "localKey" : "keyabc",
+    "orcidId" : "orc456",
+    "roles" : [ "submitter" ],
+    "@id" : "fake:user2",
+    "@type" : "User"
+  },
+  {
+    "username" : "johndoe",
+    "firstName" : "John",
+    "middleName" : "Nobody",
+    "lastName" : "Doe",
+    "displayName" : "John Doe",
+    "email" : "jd@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "jd123",
+    "localKey" : "keyabc123",
+    "orcidId" : "orc789",
+    "roles" : [ "admin" ],
+    "@id" : "fake:user3",
+    "@type" : "User"
+  }
+]

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <maven.wagon.ssh.version>2.10</maven.wagon.ssh.version>
         <maven.remote-resources.plugin.version>1.5</maven.remote-resources.plugin.version>
         <codehaus.build-helper.plugin.version>1.10</codehaus.build-helper.plugin.version>
-        <fabric8.docker.maven.plugin.version>0.23.0</fabric8.docker.maven.plugin.version>
+        <fabric8.docker.maven.plugin.version>0.24.0</fabric8.docker.maven.plugin.version>
         <slf4j.version>1.7.25</slf4j.version>
         <logback-classic.version>1.2.3</logback-classic.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
This PR includes work Elliot did to set up a Fedora server in the nihms-integration module, as well as a migration of existing fedora-builder unit tests into nihms-integration as integration tests.  These new ITs were successfully run as part of "mvn install" on a CentOS system.

Sorry about the unwanted commits as I fumbled with updating my repo from the previous PR and folding in Elliot's changes.  The consolidated code changes shown below look correct.