### PR TITLE
[DO NOT MERGE] Find files related to a Submission

### DIFF
--- a/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositFile.java
+++ b/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositFile.java
@@ -36,7 +36,7 @@ public class DepositFile {
      * Differentiates between files of the same type
      * <p>
      * Required field for {@link DepositFileType#figure}, {@link DepositFileType#table},
-     * and {@link DepositFileType#supplement} file types
+     * and {@link DepositFileType#supplemental} file types
      * </p>
      */
     private String label;

--- a/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositFileType.java
+++ b/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositFileType.java
@@ -34,7 +34,7 @@ public enum DepositFileType {
     /**
      * Supplemental data uploaded by an end-user; not a {@link #manuscript}, {@link #table}, or {@link #figure}.
      */
-    supplement,
+    supplemental,
 
     /**
      * Manuscript figure uploaded by an end-user.

--- a/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositManifest.java
+++ b/deposit-model/src/main/java/org/dataconservancy/nihms/model/DepositManifest.java
@@ -24,7 +24,7 @@ import java.util.List;
  *     <li>the {@link DepositFile#name name} of the file</li>
  *     <li>the {@link DepositFileType semantic type} of the file</li>
  *     <li>a label for the file, <em>required</em> for {@link DepositFileType#figure figures},
- *     {@link DepositFileType#table tables}, and {@link DepositFileType#supplement supplements}</li>
+ *     {@link DepositFileType#table tables}, and {@link DepositFileType#supplemental supplements}</li>
  * </ol>
  */
 public class DepositManifest {

--- a/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsPackageStreamIT.java
+++ b/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsPackageStreamIT.java
@@ -73,7 +73,7 @@ public class DspaceMetsPackageStreamIT {
                 new HashMap<File, DepositFileType>() {
                     {
                         put(custodialContent.get(0).getFile(), DepositFileType.manuscript);
-                        put(custodialContent.get(1).getFile(), DepositFileType.supplement);
+                        put(custodialContent.get(1).getFile(), DepositFileType.supplemental);
                     }
 
                 });

--- a/fedora-builder/pom.xml
+++ b/fedora-builder/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.dataconservancy.pass</groupId>
             <artifactId>pass-data-client</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>${pass.client.version}</version>
         </dependency>
 
         <dependency>

--- a/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -75,7 +75,6 @@ public class FilesystemModelBuilderTest {
         assertNotNull(submission.getMetadata().getManuscriptMetadata());
         assertNotNull(submission.getMetadata().getJournalMetadata());
         assertNotNull(submission.getMetadata().getArticleMetadata());
-        assertNotNull(submission.getFiles());
         assertNotNull(submission.getMetadata().getPersons());
 
         assertEquals(submission.getId(), submissionEntity.getId().toString());
@@ -84,6 +83,9 @@ public class FilesystemModelBuilderTest {
         assertEquals(submission.getMetadata().getArticleMetadata().getDoi().toString(), publication.getDoi());
         Journal journal = (Journal)entities.get(publication.getJournal());
         assertEquals(submission.getMetadata().getJournalMetadata().getJournalTitle(), journal.getName());
+
+        assertNotNull(submission.getFiles());
+        assertEquals(2, submission.getFiles().size());
     }
 
 }

--- a/fedora-builder/src/test/resources/SampleSubmissionData.json
+++ b/fedora-builder/src/test/resources/SampleSubmissionData.json
@@ -131,5 +131,35 @@
     "roles" : [ "admin" ],
     "@id" : "fake:user3",
     "@type" : "User"
-  }
+  },
+  {
+    "name" : "test_image",
+    "uri" : "https://s7.postimg.cc/62hbdkvx7/hopkins.png",
+    "description" : "A logo to test supplemental type",
+    "fileRole" : "supplemental",
+    "mimeType" : "image/png",
+    "submission" : "fake:submission1",
+    "@id" : "fake:file1",
+    "@type" : "File"
+  },
+  {
+    "name" : "test_pdf",
+    "uri" : "http://unec.edu.az/application/uploads/2014/12/pdf-sample.pdf",
+    "description" : "PDF hype to test manuscript type",
+    "fileRole" : "manuscript",
+    "mimeType" : "application/pdf",
+    "submission" : "fake:submission1",
+    "@id" : "fake:file2",
+    "@type" : "File"
+  },
+  {
+    "name" : "test_pdf_not_used",
+    "uri" : "http://www.africau.edu/images/default/sample.pdf",
+    "description" : "File resource that doesn't reference this submission",
+    "fileRole" : "manuscript",
+    "mimeType" : "application/pdf",
+    "submission" : "fake:submission2",
+    "@id" : "fake:file3",
+    "@type" : "File"
+}
 ]

--- a/fedora-builder/src/test/resources/SampleSubmissionData.json
+++ b/fedora-builder/src/test/resources/SampleSubmissionData.json
@@ -151,15 +151,5 @@
     "submission" : "fake:submission1",
     "@id" : "fake:file2",
     "@type" : "File"
-  },
-  {
-    "name" : "test_pdf_not_used",
-    "uri" : "http://www.africau.edu/images/default/sample.pdf",
-    "description" : "File resource that doesn't reference this submission",
-    "fileRole" : "manuscript",
-    "mimeType" : "application/pdf",
-    "submission" : "fake:submission2",
-    "@id" : "fake:file3",
-    "@type" : "File"
-}
+  }
 ]

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -37,7 +37,8 @@
         <pass.fedora.user>admin</pass.fedora.user>
         <pass.fedora.password>moo</pass.fedora.password>
         <pass.fedora.baseurl>http://${docker.host.address}:${fcrepo.http.port}/fcrepo/rest/</pass.fedora.baseurl>
-        <pass.elasticsearch.url>http://${docker.host.address}:${es.port}/pass/</pass.elasticsearch.url>
+        <pass.elasticsearch.host>${docker.host.address}</pass.elasticsearch.host>
+        <pass.elasticsearch.url>http://${pass.elasticsearch.host}:${es.port}/pass/</pass.elasticsearch.url>
     </properties>
 
 
@@ -261,6 +262,7 @@
                                     <FCREPO_STOMP_PORT>${fcrepo.stomp.port}</FCREPO_STOMP_PORT>
                                     <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
                                     <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld</COMPACTION_URI>
+                                    <FCREPO_LOG_LEVEL>DEBUG</FCREPO_LOG_LEVEL>
                                 </env>
                             </run>
                         </image>
@@ -269,6 +271,12 @@
                             <name>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</name>
                             <run>
                                 <skip>${indexer.skip}</skip>
+                                <wait>
+                                    <http>
+                                        <url>http://${pass.elasticsearch.host}:${es.port}/</url>
+                                    </http>
+                                    <time>120000</time>
+                                </wait>
                                 <ports>
                                     <port>${es.port}:9200</port>
                                 </ports>
@@ -293,7 +301,7 @@
                                     <PI_FEDORA_PASS>${pass.fedora.password}</PI_FEDORA_PASS>
                                     <PI_FEDORA_INTERNAL_BASE>http://fcrepo:${fcrepo.http.port}/fcrepo/rest/</PI_FEDORA_INTERNAL_BASE>
                                     <PI_ES_BASE>http://elasticsearch:9200/</PI_ES_BASE>
-                                    <PI_LOG_LEVEL>info</PI_LOG_LEVEL>
+                                    <PI_LOG_LEVEL>debug</PI_LOG_LEVEL>
                                     <PI_ES_INDEX>http://elasticsearch:9200/pass/</PI_ES_INDEX>
                                     <PI_FEDORA_JMS_BROKER>tcp://fcrepo:${fcrepo.jms.port}</PI_FEDORA_JMS_BROKER>
                                     <PI_FEDORA_JMS_QUEUE>fedora</PI_FEDORA_JMS_QUEUE>
@@ -332,7 +340,7 @@
                         <pass.fedora.user>${pass.fedora.user}</pass.fedora.user>
                         <pass.fedora.password>${pass.fedora.password}</pass.fedora.password>
                         <pass.fedora.baseurl>${pass.fedora.baseurl}</pass.fedora.baseurl>
-                        <pass.elasticsearch.url>${pass.elasticsearch.url}}</pass.elasticsearch.url>
+                        <pass.elasticsearch.url>${pass.elasticsearch.url}</pass.elasticsearch.url>
                     </systemProperties>
                 </configuration>
                 <executions>

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -241,7 +241,7 @@
                         </image>
                         <image>
                             <alias>fcrepo</alias>
-                            <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-2</name>
+                            <name>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3</name>
                             <run>
                                 <skip>${fcrepo.skip}</skip>
                                 <wait>
@@ -281,7 +281,7 @@
                         </image>
                         <image>
                             <alias>indexer</alias>
-                            <name>oapass/indexer:0.0.5-2.0-SNAPSHOT</name>
+                            <name>oapass/indexer:0.0.6-2.0-SNAPSHOT</name>
                             <run>
                                 <skip>${indexer.skip}</skip>
                                 <links>

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -108,6 +108,7 @@
         <dependency>
             <groupId>org.dataconservancy.pass</groupId>
             <artifactId>pass-data-client</artifactId>
+            <version>${pass.client.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/nihms-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
@@ -27,6 +27,7 @@ import org.dataconservancy.pass.model.Journal;
 import org.dataconservancy.pass.model.PassEntity;
 import org.dataconservancy.pass.model.Publication;
 import org.dataconservancy.pass.model.Submission;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,36 +44,33 @@ public class FcrepoModelBuilderIT {
     private DepositSubmission submission;
     private FcrepoModelBuilder underTest = new FcrepoModelBuilder();
     private String SAMPLE_SUBMISSION_RESOURCE = "SampleSubmissionData.json";
+    private HashMap<URI, PassEntity> entities = new HashMap<>();
+    private PassJsonFedoraAdapter adapter = new PassJsonFedoraAdapter();
+    private Submission submissionEntity = null;
 
     @Before
     public void setup() throws Exception {
-        // Upload sample data to Fedora repository to get its URI.
-        PassJsonFedoraAdapter reader = new PassJsonFedoraAdapter();
+        // Upload sample data to Fedora repository to get its Submission URI.
         URL sampleDataUrl = this.getClass().getResource(SAMPLE_SUBMISSION_RESOURCE);
         InputStream is = new FileInputStream(sampleDataUrl.getPath());
-        URI submissionUri = reader.jsonToFcrepo(is);
+        URI submissionUri = adapter.jsonToFcrepo(is, entities);
         is.close();
+
+        // Find the Submission entity that was uploaded
+        for (URI key : entities.keySet()) {
+            PassEntity entity = entities.get(key);
+            if (entity.getId() == submissionUri) {
+                submissionEntity = (Submission)entity;
+                break;
+            }
+        }
+
         submission = underTest.build(submissionUri.toString());
     }
 
     @Test
     public void testElementValues() {
-        // Load the PassEntity version of the sample data file
-        Submission submissionEntity = null;
-        HashMap<URI, PassEntity> entities = new HashMap<>();
-        try {
-            URL sampleDataUrl = this.getClass().getResource(SAMPLE_SUBMISSION_RESOURCE);
-            InputStream is = new FileInputStream(sampleDataUrl.getPath());
-            PassJsonFedoraAdapter reader = new PassJsonFedoraAdapter();
-            submissionEntity = reader.jsonToPass(is, entities);
-            is.close();
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
-            fail("Could not load sample data file");
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail("Could not close the sample data file");
-        }
+        assertNotNull("Could not find Submission entity", submissionEntity);
 
         // Until the data model is finalized, just check that some basic things are in order
         assertNotNull(submission.getManifest());
@@ -91,6 +89,12 @@ public class FcrepoModelBuilderIT {
 
         assertNotNull(submission.getFiles());
         assertEquals(2, submission.getFiles().size());
+    }
+
+    @After
+    public void tearDown() {
+        // Clean up the server
+        adapter.deleteFromFcrepo(entities);
     }
 
 }

--- a/nihms-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/pass/deposit/builder/fedora/FcrepoModelBuilderIT.java
@@ -80,7 +80,6 @@ public class FcrepoModelBuilderIT {
         assertNotNull(submission.getMetadata().getManuscriptMetadata());
         assertNotNull(submission.getMetadata().getJournalMetadata());
         assertNotNull(submission.getMetadata().getArticleMetadata());
-        assertNotNull(submission.getFiles());
         assertNotNull(submission.getMetadata().getPersons());
 
         // Cannot compare ID strings, as they change when uploading to a Fedora server.
@@ -89,6 +88,9 @@ public class FcrepoModelBuilderIT {
         assertEquals(submission.getMetadata().getArticleMetadata().getDoi().toString(), publication.getDoi());
         Journal journal = (Journal)entities.get(publication.getJournal());
         assertEquals(submission.getMetadata().getJournalMetadata().getJournalTitle(), journal.getName());
+
+        assertNotNull(submission.getFiles());
+        assertEquals(2, submission.getFiles().size());
     }
 
 }

--- a/nihms-integration/src/test/resources/org/dataconservancy/pass/deposit/builder/fedora/SampleSubmissionData.json
+++ b/nihms-integration/src/test/resources/org/dataconservancy/pass/deposit/builder/fedora/SampleSubmissionData.json
@@ -131,5 +131,35 @@
     "roles" : [ "admin" ],
     "@id" : "fake:user3",
     "@type" : "User"
-  }
+  },
+  {
+    "name" : "test_image",
+    "uri" : "https://s7.postimg.cc/62hbdkvx7/hopkins.png",
+    "description" : "A logo to test supplemental type",
+    "fileRole" : "supplemental",
+    "mimeType" : "image/png",
+    "submission" : "fake:submission1",
+    "@id" : "fake:file1",
+    "@type" : "File"
+  },
+  {
+    "name" : "test_pdf",
+    "uri" : "http://unec.edu.az/application/uploads/2014/12/pdf-sample.pdf",
+    "description" : "PDF hype to test manuscript type",
+    "fileRole" : "manuscript",
+    "mimeType" : "application/pdf",
+    "submission" : "fake:submission1",
+    "@id" : "fake:file2",
+    "@type" : "File"
+  },
+  {
+    "name" : "test_pdf_not_used",
+    "uri" : "http://www.africau.edu/images/default/sample.pdf",
+    "description" : "File resource that doesn't reference this submission",
+    "fileRole" : "manuscript",
+    "mimeType" : "application/pdf",
+    "submission" : "fake:submission2",
+    "@id" : "fake:file3",
+    "@type" : "File"
+}
 ]

--- a/nihms-integration/src/test/resources/org/dataconservancy/pass/deposit/builder/fedora/SampleSubmissionData.json
+++ b/nihms-integration/src/test/resources/org/dataconservancy/pass/deposit/builder/fedora/SampleSubmissionData.json
@@ -151,15 +151,5 @@
     "submission" : "fake:submission1",
     "@id" : "fake:file2",
     "@type" : "File"
-  },
-  {
-    "name" : "test_pdf_not_used",
-    "uri" : "http://www.africau.edu/images/default/sample.pdf",
-    "description" : "File resource that doesn't reference this submission",
-    "fileRole" : "manuscript",
-    "mimeType" : "application/pdf",
-    "submission" : "fake:submission2",
-    "@id" : "fake:file3",
-    "@type" : "File"
-}
+  }
 ]

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
@@ -33,7 +33,7 @@ import java.io.PrintWriter;
  *
  * where the file type is one of
  *
- * “bulksub_meta_xml”, “manuscript”, “supplement”, “figure”, or “table”
+ * “bulksub_meta_xml”, “manuscript”, “supplemental”, “figure”, or “table”
  *
  * @author Jim Martino (jrm@jhu.edu)
  */

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <sword2-client.version>0.9.3</sword2-client.version>
         <mets-api.version>1.3.0</mets-api.version>
         <tika.version>1.17</tika.version>
-        <pass.client.version>0.2.0-SNAPSHOT</pass.client.version>
+        <pass.client.version>0.3.0-SNAPSHOT</pass.client.version>
     </properties>
 
     <build>

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/DepositTestUtil.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/DepositTestUtil.java
@@ -126,8 +126,10 @@ public class DepositTestUtil {
 
         contributorOne.setFirstName("Albert");
         contributorOne.setLastName("Einstien");
+        contributorOne.setEmail("aeinstien@foo.org");
         contributorTwo.setFirstName("Stephen");
         contributorTwo.setLastName("Hawking");
+        contributorTwo.setEmail("shawking@bar.org");
 
         manuscript.setTitle("Two stupendous minds.");
         try {

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/BaseAssemblerIT.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/BaseAssemblerIT.java
@@ -202,7 +202,7 @@ public abstract class BaseAssemblerIT {
                 }
             } else {
                 try {
-                    custodialContentWithTypes.put(resource.getFile(), DepositFileType.supplement);
+                    custodialContentWithTypes.put(resource.getFile(), DepositFileType.supplemental);
                 } catch (IOException e) {
                     throw new RuntimeException(e.getMessage(), e);
                 }

--- a/sword2-transport/pom.xml
+++ b/sword2-transport/pom.xml
@@ -56,6 +56,10 @@
                     <groupId>joda-time</groupId>
                     <artifactId>joda-time</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
All of the File resources that reference the supplied Submission
resource will be retrieved from the Fedora server and included in the
deposit service data model that is being constructed.  Sample data is
updated to contain three File resources, only two of which reference the
data's Submission.

Unit and Integration tests were updated to confirm that the appropriate
number of File resources were found.  These tests passed when using the
fedora client's IT suite's Fedora and elasticsearch servers, but the ITs
did not pass when using the current deposit service's IT suite's
elasticsearch server.  Until this is resolved, these changes should not
be merged.