### PR TITLE
Handle missing Publisher link in deposit service

### DIFF
--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
@@ -248,16 +248,21 @@ abstract class ModelBuilder {
         // Available data for which there is no place in the existing deposit model:
         PmcParticipation journalParticipation = journalEntity.getPmcParticipation();
 
-        Publisher publisherEntity = (Publisher)entities.get(journalEntity.getPublisher());
-        // Available data for which there is no place in the existing deposit model:
-        String publisherName = publisherEntity.getName();
-        PmcParticipation publisherParticipation = publisherEntity.getPmcParticipation();
+        // Publishers are not currently used in deposits, and may be missing from Journal resources.
+        /*
+        if (journalEntity.getPublisher() != null) {
+            Publisher publisherEntity = (Publisher) entities.get(journalEntity.getPublisher());
+            // Available data for which there is no place in the existing deposit model:
+            String publisherName = publisherEntity.getName();
+            PmcParticipation publisherParticipation = publisherEntity.getPmcParticipation();
+        }
+        */
 
         // As of 5/14/18, the following data is available from both the Submission metadata
         // and as a member of one of the PassEntity objects referenced by the Submission:
         //      manuscript: title, abstract, volume, issue
         //      journal: title, issn, NLMTA-ID
-        // The metadata values are processed after the PassEntity objects and are
+        // The metadata values are processed AFTER the PassEntity objects so they have precedence.
         processMetadata(metadata, submissionEntity.getMetadata());
 
         // Data from the Submission's Repository resources

--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/PassJsonFedoraAdapter.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/PassJsonFedoraAdapter.java
@@ -276,8 +276,12 @@ public class PassJsonFedoraAdapter {
         entities.put(submission.getPublication(), publication);
         Journal journal = client.readResource(publication.getJournal(), Journal.class);
         entities.put(publication.getJournal(), journal);
-        Publisher publisher = client.readResource(journal.getPublisher(), Publisher.class);
-        entities.put(journal.getPublisher(), publisher);
+
+        // It is valid for a Journal to not link to a Publisher
+        if (journal.getPublisher() != null) {
+            Publisher publisher = client.readResource(journal.getPublisher(), Publisher.class);
+            entities.put(journal.getPublisher(), publisher);
+        }
 
         // Assume all repositories are unique
         for (URI repoURI : submission.getRepositories()) {

--- a/fedora-builder/src/test/resources/SampleSubmissionData.json
+++ b/fedora-builder/src/test/resources/SampleSubmissionData.json
@@ -28,15 +28,9 @@
     "issns" : [ "issn123", "issn456" ],
     "nlmta" : "AAPS PharmSci",
     "pmcParticipation" : "A",
-    "publisher" : "fake:publisher1",
+    "publisher" : "",
     "@id" : "fake:journal1",
     "@type" : "Journal"
-  },
-  {
-    "name" : "American Association of Pharmaceutical Scientists",
-    "pmcParticipation" : "A",
-    "@id" : "fake:publisher1",
-    "@type" : "Publisher"
   },
   {
     "name" : "PubMed Central",

--- a/nihms-integration/src/test/resources/org/dataconservancy/pass/deposit/builder/fedora/SampleSubmissionData.json
+++ b/nihms-integration/src/test/resources/org/dataconservancy/pass/deposit/builder/fedora/SampleSubmissionData.json
@@ -28,15 +28,9 @@
     "issns" : [ "issn123", "issn456" ],
     "nlmta" : "AAPS PharmSci",
     "pmcParticipation" : "A",
-    "publisher" : "fake:publisher1",
+    "publisher" : "",
     "@id" : "fake:journal1",
     "@type" : "Journal"
-  },
-  {
-    "name" : "American Association of Pharmaceutical Scientists",
-    "pmcParticipation" : "A",
-    "@id" : "fake:publisher1",
-    "@type" : "Publisher"
   },
   {
     "name" : "PubMed Central",


### PR DESCRIPTION
The deposit service will be seeing Journal resources that have empty
links to Publisher resources.  These Publishers are not currently needed
by the deposit service anyway, so the model builder code no longer tries
to load them.  The PassJsonFedoraAdapter no longer assumes a Journal
will link to a Publisher when it downloads data from a Fedora repo.