### PR TITLE
Add metadata file to NIHMS submission manifest

### DIFF
--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
@@ -17,6 +17,8 @@
 package org.dataconservancy.nihms.assembler.nihmsnative;
 
 import org.dataconservancy.nihms.assembler.PackageStream;
+import org.dataconservancy.nihms.model.DepositFile;
+import org.dataconservancy.nihms.model.DepositFileType;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import org.dataconservancy.nihms.assembler.MetadataBuilder;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractAssembler;
@@ -46,6 +48,13 @@ public class NihmsAssembler extends AbstractAssembler {
 
     @Override
     protected PackageStream createPackageStream(DepositSubmission submission, List<Resource> custodialResources, MetadataBuilder mb, ResourceBuilderFactory rbf) {
+        // Add manifest entry for metadata file
+        DepositFile metadataFile = new DepositFile();
+        metadataFile.setName(NihmsZippedPackageStream.METADATA_ENTRY_NAME);
+        metadataFile.setType(DepositFileType.bulksub_meta_xml);
+        metadataFile.setLabel("Metadata");
+        submission.getManifest().getFiles().add(metadataFile);
+
         NihmsZippedPackageStream stream = new NihmsZippedPackageStream(submission, custodialResources, mb, rbf);
         stream.setManifestSerializer(new NihmsManifestSerializer(submission.getManifest()));
         stream.setMetadataSerializer(new NihmsMetadataSerializer(submission.getMetadata()));

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssemblerIT.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssemblerIT.java
@@ -109,8 +109,8 @@ public class NihmsAssemblerIT extends BaseAssemblerIT {
         while (lines.hasNext()) {
             new ManifestLine(manifest, lines.nextLine(), lineCount++).assertAll();
         }
-        assertEquals("Expected one line per custodial resource in NIHMS manifest file " + manifest,
-                custodialResources.size(), lineCount);
+        assertEquals("Expected one line per custodial resource plus metadata file in NIHMS manifest file " + manifest,
+                custodialResources.size() + 1, lineCount);
     }
 
     @Test


### PR DESCRIPTION
Note that the code now expects to embargo end date to be in the format found in the sample data I was given, which is MM/DD/YY.  If that format changes, the date parsing may need to be updated.