### PR TITLE
Replace example.org in context namespace URL with oapass.org, use latest docker images to match

### DIFF
--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -192,7 +192,7 @@
                                     <PI_ES_INDEX>http://elasticsearch:9200/pass/</PI_ES_INDEX>
                                     <PI_FEDORA_JMS_BROKER>tcp://fcrepo:61616</PI_FEDORA_JMS_BROKER>
                                     <PI_FEDORA_JMS_QUEUE>fedora</PI_FEDORA_JMS_QUEUE>
-                                    <PI_TYPE_PREFIX>http://example.org/pass/</PI_TYPE_PREFIX>
+                                    <PI_TYPE_PREFIX>http://oapass.org/ns/pass#</PI_TYPE_PREFIX>
                                 </env>
                             </run>
                         </image>

--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -158,7 +158,7 @@
                                     <FCREPO_JMS_PORT>${fcrepo.jms.port}</FCREPO_JMS_PORT>
                                     <FCREPO_STOMP_PORT>${fcrepo.stomp.port}</FCREPO_STOMP_PORT>
                                     <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
-                                    <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld</COMPACTION_URI>
+                                    <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld</COMPACTION_URI>
                                     <FCREPO_LOG_LEVEL>DEBUG</FCREPO_LOG_LEVEL>
                                 </env>
                             </run>

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/Constants.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/Constants.java
@@ -91,8 +91,7 @@ public class Constants {
      */
     public static class PassType {
 
-        // TODO update name space?
-        public static final String SUBMISSION_RESOURCE = "http://example.org/pass/Submission";
+        public static final String SUBMISSION_RESOURCE = "http://oapass.org/ns/pass#Submission";
     }
 
     /**

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/FedoraMessagePolicyTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/FedoraMessagePolicyTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
  */
 public class FedoraMessagePolicyTest {
 
-    private static final String DEPOSIT_RESOURCE = "http://example.org/pass/Deposit";
+    private static final String DEPOSIT_RESOURCE = "http://oapass.org/ns/pass#Deposit";
 
     private FedoraMessagePolicy underTest;
 

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-equals.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-equals.json
@@ -2,7 +2,7 @@
   "id": "http://192.168.99.100:8080/fcrepo/rest/submissions/01/d6/60/7f/01d6607f-3ba6-4335-89d8-b904cd5b333a",
   "type": [
     "http://www.w3.org/ns/ldp#Container",
-    "http://example.org/pass/Submission",
+    "http://oapass.org/ns/pass#Submission",
     "http://fedora.info/definitions/v4/repository#Resource",
     "http://fedora.info/definitions/v4/repository#Container",
     "http://www.w3.org/ns/ldp#RDFSource",

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-missing-name.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-missing-name.json
@@ -2,7 +2,7 @@
   "id": "http://192.168.99.100:8080/fcrepo/rest/submissions/01/d6/60/7f/01d6607f-3ba6-4335-89d8-b904cd5b333a",
   "type": [
     "http://www.w3.org/ns/ldp#Container",
-    "http://example.org/pass/Submission",
+    "http://oapass.org/ns/pass#Submission",
     "http://fedora.info/definitions/v4/repository#Resource",
     "http://fedora.info/definitions/v4/repository#Container",
     "http://www.w3.org/ns/ldp#RDFSource",

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-missing-object.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-missing-object.json
@@ -2,7 +2,7 @@
   "id": "http://192.168.99.100:8080/fcrepo/rest/submissions/01/d6/60/7f/01d6607f-3ba6-4335-89d8-b904cd5b333a",
   "type": [
     "http://www.w3.org/ns/ldp#Container",
-    "http://example.org/pass/Submission",
+    "http://oapass.org/ns/pass#Submission",
     "http://fedora.info/definitions/v4/repository#Resource",
     "http://fedora.info/definitions/v4/repository#Container",
     "http://www.w3.org/ns/ldp#RDFSource",

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-not-equal.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-not-equal.json
@@ -2,7 +2,7 @@
   "id": "http://192.168.99.100:8080/fcrepo/rest/submissions/01/d6/60/7f/01d6607f-3ba6-4335-89d8-b904cd5b333a",
   "type": [
     "http://www.w3.org/ns/ldp#Container",
-    "http://example.org/pass/Submission",
+    "http://oapass.org/ns/pass#Submission",
     "http://fedora.info/definitions/v4/repository#Resource",
     "http://fedora.info/definitions/v4/repository#Container",
     "http://www.w3.org/ns/ldp#RDFSource",

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-web-browser.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/policy/software-agent-web-browser.json
@@ -2,7 +2,7 @@
   "id": "http://192.168.99.100:8080/fcrepo/rest/submissions/01/d6/60/7f/01d6607f-3ba6-4335-89d8-b904cd5b333a",
   "type": [
     "http://www.w3.org/ns/ldp#Container",
-    "http://example.org/pass/Submission",
+    "http://oapass.org/ns/pass#Submission",
     "http://fedora.info/definitions/v4/repository#Resource",
     "http://fedora.info/definitions/v4/repository#Container",
     "http://www.w3.org/ns/ldp#RDFSource",

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/service/message_payload.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/service/message_payload.json
@@ -2,7 +2,7 @@
   "id": "http://192.168.99.100:8080/fcrepo/rest/submissions/0f/20/05/d7/0f2005d7-0dad-4ee1-812d-00509cc8f362",
   "type": [
     "http://www.w3.org/ns/ldp#Container",
-    "http://example.org/pass/Submission",
+    "http://oapass.org/ns/pass#Submission",
     "http://fedora.info/definitions/v4/repository#Resource",
     "http://fedora.info/definitions/v4/repository#Container",
     "http://www.w3.org/ns/ldp#RDFSource",

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/support/JsonParserTest-parseId.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/support/JsonParserTest-parseId.json
@@ -2,7 +2,7 @@
   "id": "http://fcrepo:8080/fcrepo/rest/submissions/92/42/2a/d3/92422ad3-6384-46cf-98ff-332ff151000b",
   "type": [
     "http://www.w3.org/ns/ldp#Container",
-    "http://example.org/pass/Submission",
+    "http://oapass.org/ns/pass#Submission",
     "http://fedora.info/definitions/v4/repository#Resource",
     "http://fedora.info/definitions/v4/repository#Container",
     "http://www.w3.org/ns/ldp#RDFSource",

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/support/JsonParserTest-parseRepositories.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/support/JsonParserTest-parseRepositories.json
@@ -32,7 +32,7 @@
     }
   ],
   "@context": {
-    "pass": "http://example.org/pass/",
+    "pass": "http://oapass.org/ns/pass#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "Deposit": "pass:Deposit",
     "Funder": "pass:Funder",

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/support/JsonParserTest-parseRepositories2.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/support/JsonParserTest-parseRepositories2.json
@@ -29,7 +29,7 @@
     }
   ],
   "@context": {
-    "pass": "http://example.org/pass/",
+    "pass": "http://oapass.org/ns/pass#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "Deposit": "pass:Deposit",
     "Funder": "pass:Funder",

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -306,7 +306,7 @@
                                     <PI_ES_INDEX>http://elasticsearch:9200/pass/</PI_ES_INDEX>
                                     <PI_FEDORA_JMS_BROKER>tcp://fcrepo:${fcrepo.jms.port}</PI_FEDORA_JMS_BROKER>
                                     <PI_FEDORA_JMS_QUEUE>fedora</PI_FEDORA_JMS_QUEUE>
-                                    <PI_TYPE_PREFIX>http://example.org/pass/</PI_TYPE_PREFIX>
+                                    <PI_TYPE_PREFIX>http://oapass.org/ns/pass#</PI_TYPE_PREFIX>
                                 </env>
                             </run>
                         </image>

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -262,7 +262,7 @@
                                     <FCREPO_JMS_PORT>${fcrepo.jms.port}</FCREPO_JMS_PORT>
                                     <FCREPO_STOMP_PORT>${fcrepo.stomp.port}</FCREPO_STOMP_PORT>
                                     <FCREPO_ACTIVEMQ_CONFIGURATION>classpath:/activemq-queue.xml</FCREPO_ACTIVEMQ_CONFIGURATION>
-                                    <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld</COMPACTION_URI>
+                                    <COMPACTION_URI>https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld</COMPACTION_URI>
                                     <FCREPO_LOG_LEVEL>DEBUG</FCREPO_LOG_LEVEL>
                                 </env>
                             </run>

--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
         <tika.version>1.17</tika.version>
         <pass-client.version>0.3.0-SNAPSHOT</pass-client.version>
 
-        <docker.fcrepo.version>oapass/fcrepo:4.7.5-2.0-SNAPSHOT-6</docker.fcrepo.version>
-        <docker.indexer.version>oapass/indexer:0.0.6-2.0-SNAPSHOT</docker.indexer.version>
+        <docker.fcrepo.version>oapass/fcrepo:4.7.5-2.2-SNAPSHOT</docker.fcrepo.version>
+        <docker.indexer.version>oapass/indexer:0.0.10-2.2-SNAPSHOT</docker.indexer.version>
         <docker.elasticsearch.version>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</docker.elasticsearch.version>
 
         <!-- TODO properly tag these images -->


### PR DESCRIPTION
Latest context version 2.2 now uses the oapass.org namespace. This implements the namespace change and points to latest docker images which have been updated to support the new context version.