### PR TITLE
Update the aggregated deposit status of Submissions

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/AgentPolicy.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/AgentPolicy.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.policy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dataconservancy.pass.deposit.messaging.service.DepositUtil;
+import org.dataconservancy.pass.deposit.messaging.support.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * <em>Rejects</em> JMS messages that originate from the user agent supplied on construction.
+ * <p>
+ * The intent of this policy is to reject JMS messages that are emitted due to the actions of Deposit Services on
+ * Fedora resources.  If Deposit Services modifies a {@code Submission}, for example, it will receive a JMS notification
+ * for that modification.  Currently, there is no need to process those messages, and this policy insures that they will
+ * be dropped.
+ * </p>
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@Component
+public class AgentPolicy implements Policy<DepositUtil.MessageContext> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AgentPolicy.class);
+
+    private ObjectMapper objectMapper;
+
+    private String depositServicesUserAgent;
+
+    /**
+     * Constructs a new policy using the supplied {@code ObjectMapper} for parsing the user agent from the JMS message.
+     *
+     * @param objectMapper parses the JMS message body
+     * @param userAgent the user agent used by Deposit Services when interacting with the Fedora repository
+     */
+    public AgentPolicy(ObjectMapper objectMapper, @Value("${pass.deposit.http.agent}") String userAgent) {
+        if (objectMapper == null) {
+            throw new IllegalArgumentException("ObjectMapper must not be null.");
+        }
+        if (userAgent == null || userAgent.trim().length() == 0) {
+            throw new IllegalArgumentException("User Agent String must not be null or empty.");
+        }
+        this.objectMapper = objectMapper;
+        this.depositServicesUserAgent = userAgent;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <h4>Implementation notes</h4>
+     * Attempts to parse the JMS message body for a value of the {@code http://www.w3.org/ns/prov#SoftwareAgent}
+     * property.  If the value is {@code null} or does <em>not</em> equal the user agent string supplied on
+     * construction, the message is <em>accepted</em>.  If the value is equal to the user agent string supplied on
+     * construction, this policy drops the message.
+     *
+     * @param messageContext {@inheritDoc}
+     * @return false if the JMS message user agent is equal to the user agent string supplied on construction
+     */
+    @Override
+    public boolean accept(DepositUtil.MessageContext messageContext) {
+        JsonNode attribution = null;
+        try {
+            attribution = objectMapper.readTree(messageContext.message().getPayload().toString()).findValue
+                    ("wasAttributedTo");
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to parse JMS message body: " + e.getMessage(), e);
+        }
+
+        if (attribution != null) {
+            for (Iterator<JsonNode> itr = attribution.elements(); itr.hasNext();) {
+                JsonNode node = itr.next();
+                if (node.has("type") && node.findValue("type").textValue()
+                        .equals(Constants.Prov.SOFTWARE_AGENT)) {
+                    if (node.has("name") && node.findValue("name").textValue()
+                            .equals(depositServicesUserAgent)) {
+                        LOG.trace(">>>> Dropping message that originated from this agent: {}",
+                                depositServicesUserAgent);
+                        return false;
+                    } else {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // TODO: pluggable null semantic
+        return true;
+    }
+
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/DepositMessagePolicy.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/DepositMessagePolicy.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.policy;
+
+import org.dataconservancy.pass.model.Deposit;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.dataconservancy.pass.deposit.messaging.support.Constants.JmsFcrepoEvent.RESOURCE_CREATION;
+import static org.dataconservancy.pass.deposit.messaging.support.Constants.JmsFcrepoEvent.RESOURCE_MODIFICATION;
+import static org.dataconservancy.pass.deposit.messaging.support.Constants.PassType.DEPOSIT_RESOURCE;
+
+/**
+ * Accepts messages that represent the creation or modification of a PASS {@link Deposit}.  Messages that do not meet
+ * this {@code Policy} should be acknowledged immediately, with no further processing taking place.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@Component
+public class DepositMessagePolicy extends FedoraMessagePolicy {
+
+    private static final Set<FedoraResourceEventType> DEPOSIT_RESOURCE_EVENT_TYPES = Collections.unmodifiableSet(
+            new HashSet<FedoraResourceEventType>() {
+                {
+                    add(new FedoraResourceEventType(DEPOSIT_RESOURCE, RESOURCE_CREATION));
+                    add(new FedoraResourceEventType(DEPOSIT_RESOURCE, RESOURCE_MODIFICATION));
+                }
+            });
+
+    /**
+     * Returns {@code FedoraResourceEventType}s for {@code Deposit} creation and modification messages.
+     *
+     * @return FedoraResourceEventTypes accepting {@code Deposit} creation and modification messages
+     */
+    @Override
+    public Collection<FedoraResourceEventType> acceptableFedoraResourceEventTypes() {
+        return DEPOSIT_RESOURCE_EVENT_TYPES;
+    }
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/SubmissionMessagePolicy.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/SubmissionMessagePolicy.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.policy;
+
+import org.dataconservancy.pass.deposit.messaging.service.DepositUtil;
+import org.dataconservancy.pass.deposit.messaging.support.Constants;
+import org.dataconservancy.pass.deposit.messaging.support.Constants.JmsFcrepoEvent;
+import org.dataconservancy.pass.deposit.messaging.support.Constants.PassType;
+import org.dataconservancy.pass.model.Submission;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.dataconservancy.pass.deposit.messaging.support.Constants.JmsFcrepoEvent.RESOURCE_CREATION;
+import static org.dataconservancy.pass.deposit.messaging.support.Constants.JmsFcrepoEvent.RESOURCE_MODIFICATION;
+import static org.dataconservancy.pass.deposit.messaging.support.Constants.PassType.SUBMISSION_RESOURCE;
+
+/**
+ * Accepts messages that represent the creation or modification of a PASS {@link Submission}.  Messages that do not meet
+ * this {@code Policy} should be acknowledged immediately, with no further processing taking place.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@Component
+public class SubmissionMessagePolicy extends FedoraMessagePolicy {
+
+    private static final Set<FedoraResourceEventType> SUBMISSION_RESOURCE_EVENT_TYPES = Collections.unmodifiableSet(
+            new HashSet<FedoraResourceEventType>() {
+                {
+                    add(new FedoraResourceEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION));
+                    add(new FedoraResourceEventType(SUBMISSION_RESOURCE, RESOURCE_MODIFICATION));
+                }
+    });
+
+    private AgentPolicy agentPolicy;
+
+    public SubmissionMessagePolicy(AgentPolicy agentPolicy) {
+        this.agentPolicy = agentPolicy;
+    }
+
+    /**
+     * Accepts a message if the following conditions are true:
+     * <ul>
+     *     <li>{@link Constants.JmsFcrepoHeader#FCREPO_RESOURCE_TYPE} is a {@link PassType#SUBMISSION_RESOURCE}</li>
+     *     <li>{@link Constants.JmsFcrepoHeader#FCREPO_EVENT_TYPE} is a {@link JmsFcrepoEvent#RESOURCE_MODIFICATION} or
+     *         {@link JmsFcrepoEvent#RESOURCE_CREATION}</li>
+     *     <li>The JMS message is accepted according to the {@link AgentPolicy}</li>
+     * </ul>
+     *
+     * @param messageContext the {@code MessageContext} which carries the original JMS message
+     * @return {@code true} if the message represents the creation or modification of a {@code Submission}
+     */
+    @Override
+    public boolean accept(DepositUtil.MessageContext messageContext) {
+        boolean result = super.accept(messageContext);
+        if (!result) {
+            return false;
+        }
+
+        return agentPolicy.accept(messageContext);
+    }
+
+    /**
+     * Returns {@code FedoraResourceEventType}s for {@code Submission} creation and modification messages.
+     *
+     * @return FedoraResourceEventTypes accepting {@code Submission} creation and modification messages
+     */
+    @Override
+    public Collection<FedoraResourceEventType> acceptableFedoraResourceEventTypes() {
+        return SUBMISSION_RESOURCE_EVENT_TYPES;
+    }
+
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/runner/ListenerRunner.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/runner/ListenerRunner.java
@@ -39,7 +39,7 @@ public class ListenerRunner implements ApplicationContextAware {
 
     private static final Logger LOG = LoggerFactory.getLogger(ListenerRunner.class);
 
-    private static final int TEN_MINUTES = 60 * 60 * 1000 * 10;
+    private static final int TEN_MINUTES = 60 * 1000 * 10;
 
     private ApplicationContext appCtx;
 
@@ -60,6 +60,7 @@ public class ListenerRunner implements ApplicationContextAware {
                         "Any exceptions thrown after this message can be ignored.", fcrepoBaseUrl);
                 SpringApplication.exit(appCtx, () -> 1);
             }
+
             LOG.info("Fedora repository is up at '{}'", fcrepoBaseUrl);
         };
     }

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/JmsDepositProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/JmsDepositProcessor.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.deposit.messaging.service;
+
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.deposit.messaging.policy.JmsMessagePolicy;
+import org.dataconservancy.pass.deposit.messaging.policy.Policy;
+import org.dataconservancy.pass.deposit.messaging.support.Constants;
+import org.dataconservancy.pass.deposit.messaging.support.CriticalRepositoryInteraction;
+import org.dataconservancy.pass.deposit.messaging.support.JsonParser;
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Submission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.jms.support.JmsHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+import javax.jms.Session;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.dataconservancy.pass.deposit.messaging.service.DepositUtil.ackMessage;
+import static org.dataconservancy.pass.deposit.messaging.service.DepositUtil.toMessageContext;
+import static org.dataconservancy.pass.model.Deposit.DepositStatus.ACCEPTED;
+
+@Component
+public class JmsDepositProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JmsDepositProcessor.class);
+
+    private JmsMessagePolicy messagePolicy;
+
+    private Policy<Deposit.DepositStatus> terminalStatusPolicy;
+
+    private JsonParser jsonParser;
+
+    private CriticalRepositoryInteraction critical;
+
+    private PassClient passClient;
+
+    @Autowired
+    public JmsDepositProcessor(@Qualifier("depositMessagePolicy") JmsMessagePolicy messagePolicy,
+                               @Qualifier("terminalDepositStatusPolicy") Policy<Deposit.DepositStatus> statusPolicy,
+                               JsonParser jsonParser, CriticalRepositoryInteraction critical, PassClient passClient) {
+        this.messagePolicy = messagePolicy;
+        this.terminalStatusPolicy = statusPolicy;
+        this.jsonParser = jsonParser;
+        this.critical = critical;
+        this.passClient = passClient;
+    }
+
+    @JmsListener(destination = "deposit")
+    public void processMessage(@Header(Constants.JmsFcrepoHeader.FCREPO_RESOURCE_TYPE) String resourceType,
+                               @Header(Constants.JmsFcrepoHeader.FCREPO_EVENT_TYPE) String eventType,
+                               @Header(JmsHeaders.TIMESTAMP) long timeStamp,
+                               @Header(JmsHeaders.MESSAGE_ID) String id,
+                               Session session,
+                               Message<String> message,
+                               javax.jms.Message jmsMessage) {
+
+        DepositUtil.MessageContext mc = toMessageContext(
+                resourceType, eventType, timeStamp, id, session, message, jmsMessage);
+        LOG.trace(">>>> Processing message (ack mode: {}): {} {}", mc.ackMode(), mc.dateTime(), mc.id());
+        LOG.trace(">>>> Message {} body:{}", mc.id(), mc.message().getPayload());
+
+        // verify the message is one we want, otherwise ack it right away and return
+        if (!messagePolicy.accept(mc)) {
+            ackMessage(mc);
+            return;
+        }
+
+        // Parse the identity of the Deposit and Submission from the message
+        URI submissionUri;
+        try {
+            byte[] payload = mc.message().getPayload().getBytes(Charset.forName("UTF-8"));
+            URI depositUri = URI.create(jsonParser.parseId(payload));
+
+            // If the status of the incoming Deposit is not terminal, then there's no point in continuing.
+            // *All* Deposit resources for a Submission must be terminal before proceeding
+            if (! terminalStatusPolicy.accept(passClient.readResource(depositUri, Deposit.class).getDepositStatus())) {
+                return;
+            }
+            submissionUri = passClient.readResource(depositUri, Deposit.class).getSubmission();
+        } catch (Exception e) {
+            LOG.error("Error parsing deposit URI from message: {}", e.getMessage(), e);
+            return;
+        } finally {
+            ackMessage(mc);
+        }
+
+        // obtain a critical over the submission
+        critical.performCritical(submissionUri, Submission.class,
+                (submission) -> true,
+                (submission) -> true,
+                (submission) -> {
+                    Collection<Deposit> deposits = passClient.getIncoming(submission.getId())
+                        .getOrDefault("submission", Collections.emptySet()).stream()
+                        .map((uri) -> {
+                            try {
+                                return passClient.readResource(uri, Deposit.class);
+                            } catch (RuntimeException e) {
+                                // ignore exceptions whose cause is related to type coercion of JSON objects
+                                if (!(e.getCause() instanceof InvalidTypeIdException)) {
+                                    throw e;
+                                }
+
+                                return null;
+                            }
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+                    // If all the statuses are terminal, then we can update the aggregated deposit status of
+                    // the submission
+                    if (deposits.stream().allMatch((deposit) ->
+                            terminalStatusPolicy.accept(deposit.getDepositStatus()))) {
+                        if (deposits.stream().allMatch((deposit) -> deposit.getDepositStatus() == ACCEPTED)) {
+                            submission.setAggregatedDepositStatus(Submission.AggregatedDepositStatus.ACCEPTED);
+                            LOG.trace(">>>> Updating {} aggregated deposit status to {}", submission.getId(), ACCEPTED);
+                        } else {
+                            submission.setAggregatedDepositStatus(Submission.AggregatedDepositStatus.REJECTED);
+                            LOG.trace(">>>> Updating {} aggregated deposit status to {}", submission.getId(),
+                                    Submission.AggregatedDepositStatus.REJECTED);
+                        }
+                    }
+
+                return submission;
+        });
+
+    }
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/JmsSubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/JmsSubmissionProcessor.java
@@ -61,23 +61,28 @@ public class JmsSubmissionProcessor extends SubmissionProcessor {
 
 
     /**
-     * Processes incoming JMS messages from the "deposit" queue, which describe the creation or updating of {@code Submission} resources in Fedora.  The {@code Submission} is resolved, and sent to the {@link SubmissionProcessor} for further processing.
+     * Processes incoming JMS messages from the "deposit" queue, which describe the creation or updating of
+     * {@code Submission} resources in Fedora.  The {@code Submission} is resolved, and sent to the
+     * {@link SubmissionProcessor} for further processing.
      *
      * @param passClient used to resolve {@code Submission} resources from the Fedora repository
      * @param jsonParser used to parse the {@code Submission} URI from the JMS message
      * @param submissionBuilder used to build a {@link DepositSubmission} from a {@code Submission}
-     * @param packagerRegistry maintains a registry of {@link Packager}s used to transfer custodial content to remote repositories
+     * @param packagerRegistry maintains a registry of {@link Packager}s used to transfer custodial content to remote
+     *                         repositories
      * @param submissionPolicy whether or not a {@code Submission} should be accepted for processing
      * @param dirtyDepositPolicy whether or not a {@code Deposit} should be accepted for processing
      * @param messagePolicy whether or not a JMS message should be accepted for processing
      * @param taskExecutor used to manage and execute deposits to remote repositories
-     * @param depositStatusMapper maps the status of a {@code Deposit} as an <em>intermediate</em> or <em>terminal</em> status
+     * @param depositStatusMapper maps the status of a {@code Deposit} as an <em>intermediate</em> or <em>terminal</em>
+     *                            status
      * @param atomStatusParser used to parse Atom feeds that result from SWORD deposits
      */
     public JmsSubmissionProcessor(PassClient passClient, JsonParser jsonParser, SubmissionBuilder submissionBuilder,
                                   Registry<Packager> packagerRegistry,
                                   @Qualifier("passUserSubmittedPolicy") SubmissionPolicy submissionPolicy,
-                                  Policy<Deposit.DepositStatus> dirtyDepositPolicy, JmsMessagePolicy messagePolicy,
+                                  Policy<Deposit.DepositStatus> dirtyDepositPolicy,
+                                  @Qualifier("submissionMessagePolicy") JmsMessagePolicy messagePolicy,
                                   TaskExecutor taskExecutor,
                                   DepositStatusMapper<SwordDspaceDepositStatus> depositStatusMapper,
                                   DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser,
@@ -88,7 +93,7 @@ public class JmsSubmissionProcessor extends SubmissionProcessor {
 
     }
 
-    @JmsListener(destination = "deposit")
+    @JmsListener(destination = "submission")
     public void processMessage(@Header(Constants.JmsFcrepoHeader.FCREPO_RESOURCE_TYPE) String resourceType,
                                @Header(Constants.JmsFcrepoHeader.FCREPO_EVENT_TYPE) String eventType,
                                @Header(JmsHeaders.TIMESTAMP) long timeStamp,
@@ -98,7 +103,8 @@ public class JmsSubmissionProcessor extends SubmissionProcessor {
                                javax.jms.Message jmsMessage) {
 
 
-        DepositUtil.MessageContext mc = toMessageContext(resourceType, eventType, timeStamp, id, session, message, jmsMessage);
+        DepositUtil.MessageContext mc =
+                toMessageContext(resourceType, eventType, timeStamp, id, session, message, jmsMessage);
         LOG.trace(">>>> Processing message (ack mode: {}): {} {}", mc.ackMode(), mc.dateTime(), mc.id());
         LOG.trace(">>>> Message {} body:{}", mc.id(), mc.message().getPayload());
         processInternal(mc);

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
@@ -90,7 +90,8 @@ public class SubmissionProcessor implements Consumer<Submission> {
                                Registry<Packager> packagerRegistry,
                                @Qualifier("alwaysTrueSubmissionPolicy") SubmissionPolicy submissionPolicy,
                                @Qualifier("dirtyDepositPolicy") Policy<Deposit.DepositStatus> dirtyDepositPolicy,
-                               JmsMessagePolicy messagePolicy, TaskExecutor taskExecutor,
+                               @Qualifier("submissionMessagePolicy") JmsMessagePolicy messagePolicy,
+                               TaskExecutor taskExecutor,
                                DepositStatusMapper<SwordDspaceDepositStatus> depositStatusMapper,
                                DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser,
                                CriticalRepositoryInteraction critical) {

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/Constants.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/Constants.java
@@ -92,6 +92,9 @@ public class Constants {
     public static class PassType {
 
         public static final String SUBMISSION_RESOURCE = "http://oapass.org/ns/pass#Submission";
+
+        public static final String DEPOSIT_RESOURCE = "http://oapass.org/ns/pass#Deposit";
+
     }
 
     /**

--- a/deposit-messaging/src/main/resources/logback.xml
+++ b/deposit-messaging/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
   <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{HH:mm:ss.SSS} [%10.30thread] %-5level [%15.-30C{0}] - %msg%n
+        %d{HH:mm:ss.SSS} [%20.20thread] %-5level [%20.-20C{0}] - %msg%n
       </pattern>
     </encoder>
     <target>System.err</target>
@@ -25,7 +25,7 @@
   <root level="WARN">
     <appender-ref ref="STDERR"/>
   </root>
-  <logger name="org.springframework" additivity="false" level="INFO">
+  <logger name="org.springframework" additivity="false" level="WARN">
     <appender-ref ref="STDERR"/>
   </logger>
   <logger name="org.dataconservancy" additivity="false" level="${org.dataconservancy.nihms.level:-DEBUG}">

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/AgentPolicyTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/AgentPolicyTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.policy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dataconservancy.pass.deposit.messaging.service.DepositUtil;
+import org.junit.Test;
+
+import static org.dataconservancy.pass.deposit.messaging.support.Constants.JmsFcrepoEvent.RESOURCE_CREATION;
+import static org.dataconservancy.pass.deposit.messaging.support.Constants.PassType.SUBMISSION_RESOURCE;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class AgentPolicyTest {
+
+    private final String AGENT_STRING = "pass-deposit/x.y.z";
+
+    @Test
+    public void denyFromSameUserAgent() throws Exception {
+        AgentPolicy agentPolicy = mock(AgentPolicy.class);
+        when(agentPolicy.accept(any())).thenReturn(false);
+        AgentPolicy underTest = new AgentPolicy(new ObjectMapper(), AGENT_STRING);
+
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-equals.json");
+        assertFalse(underTest.accept(mc));
+    }
+
+    @Test
+    public void acceptFromDifferentUserAgent() throws Exception {
+        AgentPolicy agentPolicy = mock(AgentPolicy.class);
+        when(agentPolicy.accept(any())).thenReturn(false);
+        AgentPolicy underTest = new AgentPolicy(new ObjectMapper(), AGENT_STRING);
+
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-not-equal.json");
+        assertTrue(underTest.accept(mc));
+    }
+
+    @Test
+    public void acceptAgentMissingName() throws Exception {
+        AgentPolicy agentPolicy = mock(AgentPolicy.class);
+        when(agentPolicy.accept(any())).thenReturn(false);
+        AgentPolicy underTest = new AgentPolicy(new ObjectMapper(), AGENT_STRING);
+
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-missing-name.json");
+        assertTrue(underTest.accept(mc));
+    }
+
+    @Test
+    public void acceptAgentMissingObject() throws Exception {
+        AgentPolicy agentPolicy = mock(AgentPolicy.class);
+        when(agentPolicy.accept(any())).thenReturn(false);
+        AgentPolicy underTest = new AgentPolicy(new ObjectMapper(), AGENT_STRING);
+
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-missing-object.json");
+        assertTrue(underTest.accept(mc));
+    }
+}

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/PolicyTestUtil.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/PolicyTestUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.policy;
+
+import org.apache.commons.io.IOUtils;
+import org.dataconservancy.pass.deposit.messaging.service.DepositUtil;
+import org.springframework.messaging.Message;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class PolicyTestUtil {
+    static DepositUtil.MessageContext withResourceAndEventType(String resourceType, String eventType) throws IOException {
+        return withResourceAndEventType(resourceType, eventType, "software-agent-web-browser.json");
+    }
+
+    static DepositUtil.MessageContext withResourceAndEventType(String resourceType, String eventType, String
+            messageBodyResource) throws IOException {
+        DepositUtil.MessageContext mc = mock(DepositUtil.MessageContext.class);
+
+        when(mc.eventType()).thenReturn(eventType);
+        when(mc.resourceType()).thenReturn(resourceType);
+
+        Instant now = Instant.now();
+        when(mc.timestamp()).thenReturn(now.toEpochMilli());
+        String formattedNow = DateTimeFormatter.ISO_DATE_TIME.format(now.atZone(ZoneId.of("UTC")));
+        when(mc.dateTime()).thenReturn(formattedNow);
+
+        when(mc.id()).thenReturn(UUID.randomUUID().toString());
+
+        Message message = mock(Message.class);
+        when(mc.message()).thenReturn(message);
+
+        when(message.getPayload()).thenReturn(
+                IOUtils.toString(
+                        SubmissionMessagePolicyTest.class.getResourceAsStream(messageBodyResource), "UTF-8"));
+
+        return mc;
+    }
+}

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/SubmissionMessagePolicyTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/SubmissionMessagePolicyTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -99,7 +100,13 @@ public class SubmissionMessagePolicyTest {
     @Test
     public void denyFromSameUserAgent() throws Exception {
         DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-equals.json");
+
+        AgentPolicy agentPolicy = mock(AgentPolicy.class);
+        when(agentPolicy.accept(mc)).thenReturn(false);
+        underTest = new SubmissionMessagePolicy(agentPolicy);
+
         assertFalse(underTest.accept(mc));
+        verify(agentPolicy).accept(mc);
     }
 
     @Test

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/SubmissionMessagePolicyTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/SubmissionMessagePolicyTest.java
@@ -15,17 +15,9 @@
  */
 package org.dataconservancy.pass.deposit.messaging.policy;
 
-import org.apache.commons.io.IOUtils;
 import org.dataconservancy.pass.deposit.messaging.service.DepositUtil;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.messaging.Message;
-
-import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.UUID;
 
 import static org.dataconservancy.pass.deposit.messaging.support.Constants.JmsFcrepoEvent.RESOURCE_CREATION;
 import static org.dataconservancy.pass.deposit.messaging.support.Constants.JmsFcrepoEvent.RESOURCE_MODIFICATION;
@@ -54,101 +46,72 @@ public class SubmissionMessagePolicyTest {
 
     @Test
     public void acceptCreationOfSubmission() throws Exception {
-        DepositUtil.MessageContext mc = withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION);
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION);
         assertTrue(underTest.accept(mc));
     }
 
     @Test
     public void acceptModificationOfSubmission() throws Exception {
-        DepositUtil.MessageContext mc = withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION);
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION);
         assertTrue(underTest.accept(mc));
     }
 
     @Test
     public void acceptCreationOfSubmissionWithMultipleResources() throws Exception {
         String resource = String.format("%s, %s, %s", "http://foo/bar", SUBMISSION_RESOURCE, "http://biz/baz");
-        DepositUtil.MessageContext mc = withResourceAndEventType(resource, RESOURCE_CREATION);
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(resource, RESOURCE_CREATION);
         assertTrue(underTest.accept(mc));
     }
 
     @Test
     public void acceptModificationOfSubmissionWithMultipleResources() throws Exception {
         String resource = String.format("%s, %s, %s", "http://foo/bar", SUBMISSION_RESOURCE, "http://biz/baz");
-        DepositUtil.MessageContext mc = withResourceAndEventType(resource, RESOURCE_MODIFICATION);
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(resource, RESOURCE_MODIFICATION);
         assertTrue(underTest.accept(mc));
     }
 
     @Test
     public void denyModificationOfNonSubmissions() throws Exception {
-        DepositUtil.MessageContext mc = withResourceAndEventType(DEPOSIT_RESOURCE, RESOURCE_CREATION);
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(DEPOSIT_RESOURCE, RESOURCE_CREATION);
         assertFalse(underTest.accept(mc));
     }
 
     @Test
     public void denyCreationOfNonSubmissions() throws Exception {
-        DepositUtil.MessageContext mc = withResourceAndEventType(DEPOSIT_RESOURCE, RESOURCE_CREATION);
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(DEPOSIT_RESOURCE, RESOURCE_CREATION);
         assertFalse(underTest.accept(mc));
     }
 
     @Test
     public void denyCreationOfNonSubmissionsWithMultipleResources() throws Exception {
         String resource = String.format("%s, %s, %s", "http://foo/bar", DEPOSIT_RESOURCE, "http://biz/baz");
-        DepositUtil.MessageContext mc = withResourceAndEventType(resource, RESOURCE_CREATION);
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(resource, RESOURCE_CREATION);
         assertFalse(underTest.accept(mc));
     }
 
     @Test
     public void denyModificationsOfNonSubmissionsWithMultipleResources() throws Exception {
         String resource = String.format("%s, %s, %s", "http://foo/bar", DEPOSIT_RESOURCE, "http://biz/baz");
-        DepositUtil.MessageContext mc = withResourceAndEventType(resource, RESOURCE_MODIFICATION);
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(resource, RESOURCE_MODIFICATION);
         assertFalse(underTest.accept(mc));
     }
 
     @Test
     public void denyFromSameUserAgent() throws Exception {
-        DepositUtil.MessageContext mc = withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-equals.json");
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-equals.json");
         assertFalse(underTest.accept(mc));
     }
 
     @Test
     public void acceptFromMissingAgentName() throws Exception {
-        DepositUtil.MessageContext mc = withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-missing-name.json");
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-missing-name.json");
         assertTrue(underTest.accept(mc));
     }
 
     @Test
     public void acceptWhenMissingAttribution() throws Exception {
-        DepositUtil.MessageContext mc = withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-missing-object.json");
+        DepositUtil.MessageContext mc = PolicyTestUtil.withResourceAndEventType(SUBMISSION_RESOURCE, RESOURCE_CREATION, "software-agent-missing-object.json");
         assertTrue(underTest.accept(mc));
     }
-
-    private static DepositUtil.MessageContext withResourceAndEventType(String resourceType, String eventType) throws IOException {
-        return withResourceAndEventType(resourceType, eventType, "software-agent-web-browser.json");
-    }
-
-    private static DepositUtil.MessageContext withResourceAndEventType(String resourceType, String eventType,
-                                                                       String messageBodyResource) throws IOException {
-        DepositUtil.MessageContext mc = mock(DepositUtil.MessageContext.class);
-
-        when(mc.eventType()).thenReturn(eventType);
-        when(mc.resourceType()).thenReturn(resourceType);
-
-        Instant now = Instant.now();
-        when(mc.timestamp()).thenReturn(now.toEpochMilli());
-        String formattedNow = DateTimeFormatter.ISO_DATE_TIME.format(now.atZone(ZoneId.of("UTC")));
-        when(mc.dateTime()).thenReturn(formattedNow);
-
-        when(mc.id()).thenReturn(UUID.randomUUID().toString());
-
-        Message message = mock(Message.class);
-        when(mc.message()).thenReturn(message);
-
-        when(message.getPayload()).thenReturn(
-                IOUtils.toString(
-                        SubmissionMessagePolicyTest.class.getResourceAsStream(messageBodyResource), "UTF-8"));
-
-        return mc;
-    }
-
 
 }

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/SubmissionMessagePolicyTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/SubmissionMessagePolicyTest.java
@@ -15,7 +15,6 @@
  */
 package org.dataconservancy.pass.deposit.messaging.policy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.dataconservancy.pass.deposit.messaging.service.DepositUtil;
 import org.junit.Before;
@@ -33,21 +32,24 @@ import static org.dataconservancy.pass.deposit.messaging.support.Constants.JmsFc
 import static org.dataconservancy.pass.deposit.messaging.support.Constants.PassType.SUBMISSION_RESOURCE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
  * @author Elliot Metsger (emetsger@jhu.edu)
  */
-public class FedoraMessagePolicyTest {
+public class SubmissionMessagePolicyTest {
 
     private static final String DEPOSIT_RESOURCE = "http://oapass.org/ns/pass#Deposit";
 
-    private FedoraMessagePolicy underTest;
+    private SubmissionMessagePolicy underTest;
 
     @Before
     public void setUp() throws Exception {
-        underTest = new FedoraMessagePolicy(new ObjectMapper(), "pass-deposit/x.y.z");
+        AgentPolicy agentPolicy = mock(AgentPolicy.class);
+        when(agentPolicy.accept(any())).thenReturn(true);
+        underTest = new SubmissionMessagePolicy(agentPolicy);
     }
 
     @Test
@@ -143,7 +145,7 @@ public class FedoraMessagePolicyTest {
 
         when(message.getPayload()).thenReturn(
                 IOUtils.toString(
-                        FedoraMessagePolicyTest.class.getResourceAsStream(messageBodyResource), "UTF-8"));
+                        SubmissionMessagePolicyTest.class.getResourceAsStream(messageBodyResource), "UTF-8"));
 
         return mc;
     }

--- a/deposit-messaging/src/test/resources/logback-test.xml
+++ b/deposit-messaging/src/test/resources/logback-test.xml
@@ -17,7 +17,7 @@
   <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{HH:mm:ss.SSS} [%10.30thread] %-5level [%15.-30C{0}] - %msg%n
+        %d{HH:mm:ss.SSS} [%20.20thread] %-5level [%20.-20C{0}] - %msg%n
       </pattern>
     </encoder>
     <target>System.err</target>

--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/PassJsonFedoraAdapter.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/PassJsonFedoraAdapter.java
@@ -226,7 +226,6 @@ public class PassJsonFedoraAdapter {
             } else if (entity instanceof Policy) {
                 Policy policy = (Policy)entity;
                 policy.setInstitution(uriMap.get(policy.getInstitution()));
-                policy.setFunder(uriMap.get(policy.getFunder()));
                 policy.setRepositories(getUpdatedUris(uriMap, policy.getRepositories()));
             } else if (entity instanceof Journal) {
                 Journal journal = (Journal)entity;

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <sword2-client.version>0.9.3</sword2-client.version>
         <mets-api.version>1.3.0</mets-api.version>
         <tika.version>1.17</tika.version>
-        <pass-client.version>0.3.0-SNAPSHOT</pass-client.version>
+        <pass-client.version>0.3.2-SNAPSHOT</pass-client.version>
 
         <docker.fcrepo.version>oapass/fcrepo:4.7.5-2.2-SNAPSHOT</docker.fcrepo.version>
         <docker.indexer.version>oapass/indexer:0.0.10-2.2-SNAPSHOT</docker.indexer.version>


### PR DESCRIPTION
This PR is a bit of a mixed bag, but submitted as one for efficiency.

1) Upgrades to the latest pass client, which brings deposit services up-to-date with the use of the JSON-LD context v 2.2.
2) Minor bug fix to a constant value
3) Updates log formatting to use fixed width to make reading messages easier
4) Additional javadoc and code formatting

When this PR is merged, version 0.0.2 of Deposit Services can be released and incorporated into `pass-docker`.