### PR TITLE
Fixes for PI/author data in NIHMS metadata

### DIFF
--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
@@ -225,7 +225,7 @@ abstract class ModelBuilder {
 
         // Data from the Submission's user resource
         User userEntity = (User)entities.get(submissionEntity.getUser());
-        persons.add(createPerson(userEntity, false, false, true));
+        persons.add(createPerson(userEntity, true, true, false));
 
         // Data from the Submission's Publication resource and its referenced Journal and Publisher resources
         Publication publicationEntity = (Publication)entities.get(submissionEntity.getPublication());
@@ -318,7 +318,7 @@ abstract class ModelBuilder {
             persons.add(createPerson(piEntity, true, false, false));
             for (URI copiUri : grantEntity.getCoPis()) {
                 User copiEntity = (User)entities.get(copiUri);
-                persons.add(createPerson(copiEntity, false, true, false));
+                persons.add(createPerson(copiEntity, true, false, false));
             }
         }
 

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
@@ -140,24 +140,28 @@ public class NihmsMetadataSerializer implements StreamingSerializer{
             if (persons.size()>0) {
                 writer.startNode("contacts");
                 for (DepositMetadata.Person person : persons){
-                    writer.startNode("person");
-                    if (person.getFirstName() != null) {
-                        writer.addAttribute("fname",person.getFirstName());
+                    // There should be exactly one corresponding PI per deposit.
+                    if (person.isCorrespondingPi()) {
+                        writer.startNode("person");
+                        if (person.getFirstName() != null) {
+                            writer.addAttribute("fname", person.getFirstName());
+                        }
+                        if (person.getMiddleName() != null) {
+                            writer.addAttribute("mname", person.getMiddleName());
+                        }
+                        if (person.getLastName() != null) {
+                            writer.addAttribute("lname", person.getLastName());
+                        }
+                        if (person.getEmail() != null) {
+                            writer.addAttribute("email", person.getEmail());
+                        }
+                        //primitive types
+                        writer.addAttribute("pi", booleanConvert(person.isPi()));
+                        writer.addAttribute("corrpi", booleanConvert(person.isCorrespondingPi()));
+                        // Author status is not known from Submission data and is optional, so do not include it.
+                        writer.endNode(); // end person
+                        break; // Make sure we only write one person to the metadata
                     }
-                    if (person.getMiddleName() != null) {
-                        writer.addAttribute("mname",person.getMiddleName());
-                    }
-                    if (person.getLastName() != null) {
-                        writer.addAttribute("lname",person.getLastName());
-                    }
-                    if (person.getEmail() != null) {
-                        writer.addAttribute("email",person.getEmail());
-                    }
-                    //primitive types
-                    writer.addAttribute("pi", booleanConvert(person.isPi()));
-                    writer.addAttribute("corrpi", booleanConvert(person.isCorrespondingPi()));
-                    writer.addAttribute("author", booleanConvert(person.isAuthor()));
-                    writer.endNode(); // end person
                 }
                 writer.endNode(); //end contacts
             }

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssemblerIT.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssemblerIT.java
@@ -159,14 +159,16 @@ public class NihmsAssemblerIT extends BaseAssemblerIT {
         }).collect(Collectors.toList());
 
         // Assert that each person present in the Submission is present in the metadata
-        assertEquals(submission.getMetadata().getPersons().size(), personElements.size());
+        assertEquals(1, personElements.size());
         submission.getMetadata().getPersons().forEach(p -> {
-            assertTrue(asPersons.stream().anyMatch(candidate ->
-                    candidate.getFirstName().equals(p.getFirstName()) &&
-                    candidate.getLastName().equals(p.getLastName()) &&
-                    candidate.isAuthor() == p.isAuthor() &&
-                    candidate.isPi() == p.isPi() &&
-                    candidate.isCorrespondingPi() == p.isCorrespondingPi()));
+            if (p.isCorrespondingPi()) {
+                assertTrue(asPersons.stream().anyMatch(candidate ->
+                        candidate.getFirstName().equals(p.getFirstName()) &&
+                                candidate.getLastName().equals(p.getLastName()) &&
+                                candidate.isAuthor() == p.isAuthor() &&
+                                candidate.isPi() == p.isPi() &&
+                                candidate.isCorrespondingPi() == p.isCorrespondingPi()));
+            }
         });
 
         // Assert that the DOI is present in the metadata

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/DepositTestUtil.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/DepositTestUtil.java
@@ -127,6 +127,8 @@ public class DepositTestUtil {
         contributorOne.setFirstName("Albert");
         contributorOne.setLastName("Einstien");
         contributorOne.setEmail("aeinstien@foo.org");
+        contributorOne.setCorrespondingPi(true);
+        contributorOne.setPi(true);
         contributorTwo.setFirstName("Stephen");
         contributorTwo.setLastName("Hawking");
         contributorTwo.setEmail("shawking@bar.org");


### PR DESCRIPTION
The PI info in the NIHMS metadata file should be based on the
information in a Submission resource.  There should only be one PI
listed here, and they should be noted as the corresponding PI.  The
Submission does not include any information about whether this PI is an
author, so that property is now omitted.

Some naming confusion is also cleared up regarding the "copi" members of
a Grant.  They are now added to the deposit metadata people list, but no
longer as corresponding PIs.  None of these PIs are flagged as authors,
as that information is not present at the time of their creation.