### PR TITLE
Update ConflictHandler interface

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.Map;
 
 import static java.lang.Integer.toHexString;
 import static java.lang.String.format;
@@ -133,8 +134,9 @@ public class DepositTask implements Runnable {
                 (deposit) -> {
                     Packager packager = dc.packager();
                     PackageStream packageStream = packager.getAssembler().assemble(dc.depositSubmission());
-                    try (TransportSession transport = packager.getTransport().open(packager.getConfiguration())) {
-                        TransportResponse tr = transport.send(packageStream, packager.getConfiguration());
+                    Map<String, String> packagerConfig = packager.getConfiguration();
+                    try (TransportSession transport = packager.getTransport().open(packagerConfig)) {
+                        TransportResponse tr = transport.send(packageStream, packagerConfig);
                         deposit.setDepositStatus(SUBMITTED);
                         return tr;
                     } catch (Exception e) {

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositUtil.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositUtil.java
@@ -89,7 +89,6 @@ public class DepositUtil {
             JmsProperties.AcknowledgeMode mode = asAcknowledgeMode(session.getAcknowledgeMode());
             ackMode = mode.name();
         } catch (Exception e) {
-            LOG.trace("Unknown acknowledgement mode for message received {}, id: {}", dateTime, id);
             ackMode = "UNKNOWN";
         }
         return ackMode;

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/JmsDepositProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/JmsDepositProcessor.java
@@ -84,8 +84,8 @@ public class JmsDepositProcessor {
 
         DepositUtil.MessageContext mc = toMessageContext(
                 resourceType, eventType, timeStamp, id, session, message, jmsMessage);
-        LOG.trace(">>>> Processing message (ack mode: {}): {} {}", mc.ackMode(), mc.dateTime(), mc.id());
-        LOG.trace(">>>> Message {} body:{}", mc.id(), mc.message().getPayload());
+        LOG.trace(">>>> Processing message (ack mode: {}) {} body:\n{}",
+                mc.ackMode(), mc.id(), mc.message().getPayload());
 
         // verify the message is one we want, otherwise ack it right away and return
         if (!messagePolicy.accept(mc)) {

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/JmsSubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/JmsSubmissionProcessor.java
@@ -105,8 +105,8 @@ public class JmsSubmissionProcessor extends SubmissionProcessor {
 
         DepositUtil.MessageContext mc =
                 toMessageContext(resourceType, eventType, timeStamp, id, session, message, jmsMessage);
-        LOG.trace(">>>> Processing message (ack mode: {}): {} {}", mc.ackMode(), mc.dateTime(), mc.id());
-        LOG.trace(">>>> Message {} body:{}", mc.id(), mc.message().getPayload());
+        LOG.trace(">>>> Processing message (ack mode: {}) {} body:\n{}",
+                mc.ackMode(), mc.id(), mc.message().getPayload());
         processInternal(mc);
     }
 

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
@@ -152,7 +152,7 @@ public class SubmissionProcessor implements Consumer<Submission> {
         DepositSubmission depositSubmission = result.result().orElseThrow(
                 () -> new RuntimeException("Missing expected DepositSubmission"));
 
-        LOG.debug(">>>> Processing Submission {}", submission);
+        LOG.debug(">>>> Processing Submission {}", submission.getId());
 
         updatedS.getRepositories().stream().map(repoUri -> passClient.readResource(repoUri, Repository.class))
                 .forEach(repo -> {
@@ -181,8 +181,8 @@ public class SubmissionProcessor implements Consumer<Submission> {
                     packager);
             DepositTask depositTask = new DepositTask(dc, passClient, atomStatusParser, depositStatusMapper, dirtyDepositPolicy, critical);
 
-            LOG.debug(">>>> Submitting task ({}@{}) to the deposit worker queue: {}",
-                    depositTask.getClass().getSimpleName(), toHexString(identityHashCode(depositTask)), depositTask);
+            LOG.debug(">>>> Submitting task ({}@{}) to the deposit worker queue for submission {}",
+                    depositTask.getClass().getSimpleName(), toHexString(identityHashCode(depositTask)), updatedS.getId());
             taskExecutor.execute(depositTask);
         });
 

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/ConflictHandler.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/ConflictHandler.java
@@ -17,11 +17,43 @@ package org.dataconservancy.pass.deposit.messaging.support;
 
 import org.dataconservancy.pass.model.PassEntity;
 
+import java.util.function.Function;
+import java.util.function.Predicate;
+
 /**
+ * {@code ConflictHandler} is invoked when a {@code 409 Conflict} or {@code 412 Precondition Failed} is returned in
+ * response to a {@code PATCH}.
+ * <p>
+ * The {@link org.dataconservancy.pass.client.PassClient} includes an {@code If-Match} header on {@code PATCH} requests
+ * to the Fedora repository.  When {@code 412 Precondition Failed} is returned, this handler is invoked to resolve the
+ * conflict.  A naive implementation may invoke a back-off and re-try the request.
+ * </p>
  * @author Elliot Metsger (emetsger@jhu.edu)
  */
 public interface ConflictHandler {
 
-    <T extends PassEntity> T handleConflict(T resource, Class<? extends T> resourceClass);
+    /**
+     * Invoked when a {@code 412 Precondition Failed} is returned from a {@code PATCH} request to the repository.
+     * <p>
+     * Implementations are provided the the resource that includes the state to be updated, the function that performs
+     * the update, and the precondition that ought to be satisfied prior to invoking the update function.
+     * </p>
+     * <p>
+     * Because this handler is being invoked in response to a {@code 412}, simply re-submitting the {PATCH} request with
+     * the supplied {@code resource} will <em>always</em> fail.  Implementations will need to re-retrieve the the latest
+     * state of the resource, optionally apply the {@code preCondition} (insuring that the new state of the resource is
+     * still valid with respect to the {@code criticalUpdate} to be applied), and invoke the {@code criticalUpdate}.
+     * </p>
+     *
+     * @param conflictedResource the resource with the state to be updated
+     * @param resourceClass the runtime class of the resource
+     * @param preCondition the precondition that must be satisfied in order for the {@code criticalUpdate} to be applied
+     * @param criticalUpdate the update to be applied to the resource
+     * @param <T> the type of resource
+     * @param <R> the type of the response returned by the {@code criticalUpdate}
+     * @return the return from the {@code criticalUpdate}
+     */
+    <T extends PassEntity, R> R handleConflict(T conflictedResource, Class<T> resourceClass,
+                                               Predicate<T> preCondition, Function<T, R> criticalUpdate);
 
 }

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/CriticalPath.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/CriticalPath.java
@@ -165,11 +165,7 @@ public class CriticalPath implements CriticalRepositoryInteraction {
                     // (presumably a merge of the state in the repository with the state from the critical function)
                     resource = conflictHandler.handleConflict(resource, clazz);
                 } catch (Exception handlerE) {
-                    // If the ConflictHandler fails, wrap the exception with an explanation
-                    RuntimeException rte = new RuntimeException(
-                            format("Error resolving conflict attempting critical update: %s",
-                                    handlerE.getMessage()), e);
-                    return new CriticalResult<>(updateResult, resource, false, rte);
+                    return new CriticalResult<>(updateResult, resource, false, handlerE);
                 }
             } catch (Exception e) {
                 return new CriticalResult<>(updateResult, resource, false, e);

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/CriticalPath.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/CriticalPath.java
@@ -163,7 +163,7 @@ public class CriticalPath implements CriticalRepositoryInteraction {
                 try {
                     // If the ConflictHandler is successful, the resource with its updated state is returned
                     // (presumably a merge of the state in the repository with the state from the critical function)
-                    resource = conflictHandler.handleConflict(resource, clazz);
+                    updateResult = conflictHandler.handleConflict(resource, clazz, precondition, critical);
                 } catch (Exception handlerE) {
                     return new CriticalResult<>(updateResult, resource, false, handlerE);
                 }


### PR DESCRIPTION
Updates the `ConflictHandler` interface to:
1. return a value compatible with `CriticalResult`
2. require the pre-condition to succeed prior to running the critical update

Includes javadoc

Reduce logging noise