### PR TITLE
Fix the filenames of resources as they appear in packages.

### DIFF
--- a/dspace-mets-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsAssembler.java
+++ b/dspace-mets-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsAssembler.java
@@ -20,10 +20,10 @@ import org.dataconservancy.nihms.assembler.MetadataBuilder;
 import org.dataconservancy.nihms.assembler.PackageStream;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractAssembler;
+import org.dataconservancy.pass.deposit.assembler.shared.DepositFileResource;
 import org.dataconservancy.pass.deposit.assembler.shared.MetadataBuilderFactory;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -58,7 +58,7 @@ public class DspaceMetsAssembler extends AbstractAssembler {
     }
 
     @Override
-    protected PackageStream createPackageStream(DepositSubmission submission, List<Resource> custodialResources,
+    protected PackageStream createPackageStream(DepositSubmission submission, List<DepositFileResource> custodialResources,
                                                 MetadataBuilder mb, ResourceBuilderFactory rbf) {
         mb.spec(SPEC_DSPACE_METS);
         mb.archive(PackageStream.ARCHIVE.ZIP);

--- a/dspace-mets-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsThreadedOutputStreamWriter.java
+++ b/dspace-mets-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsThreadedOutputStreamWriter.java
@@ -17,15 +17,12 @@ package org.dataconservancy.pass.deposit.assembler.dspace.mets;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.dataconservancy.nihms.assembler.MetadataBuilder;
 import org.dataconservancy.nihms.assembler.PackageStream;
-import org.dataconservancy.nihms.assembler.ResourceBuilder;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractThreadedOutputStreamWriter;
+import org.dataconservancy.pass.deposit.assembler.shared.DepositFileResource;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
-import org.springframework.core.io.Resource;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,7 +40,7 @@ public class DspaceMetsThreadedOutputStreamWriter extends AbstractThreadedOutput
 
     public DspaceMetsThreadedOutputStreamWriter(String threadName, ArchiveOutputStream archiveOut,
                                                 DepositSubmission submission,
-                                                List<Resource> packageFiles, ResourceBuilderFactory rbf,
+                                                List<DepositFileResource> packageFiles, ResourceBuilderFactory rbf,
                                                 MetadataBuilder metadataBuilder,
                                                 DspaceMetadataDomWriter metsWriter) {
         super(threadName, archiveOut, submission, packageFiles, rbf, metadataBuilder);
@@ -82,8 +79,8 @@ public class DspaceMetsThreadedOutputStreamWriter extends AbstractThreadedOutput
      * @return
      */
     @Override
-    protected String nameResource(Resource resource) {
-        return "data/" + resource.getFilename();
+    protected String nameResource(DepositFileResource resource) {
+        return "data/" + super.nameResource(resource);
     }
 
 }

--- a/dspace-mets-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsZippedPackageStream.java
+++ b/dspace-mets-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsZippedPackageStream.java
@@ -21,6 +21,7 @@ import org.dataconservancy.nihms.assembler.MetadataBuilder;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractZippedPackageStream;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractThreadedOutputStreamWriter;
+import org.dataconservancy.pass.deposit.assembler.shared.DepositFileResource;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
 
 import java.util.List;
@@ -34,7 +35,7 @@ public class DspaceMetsZippedPackageStream extends AbstractZippedPackageStream {
     private MetadataBuilder metadataBuilder;
 
     public DspaceMetsZippedPackageStream(DepositSubmission submission,
-                                         List<org.springframework.core.io.Resource> custodialResources,
+                                         List<DepositFileResource> custodialResources,
                                          MetadataBuilder metadataBuilder, ResourceBuilderFactory rbf,
                                          DspaceMetadataDomWriter metsWriter) {
 

--- a/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsPackageStreamIT.java
+++ b/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsPackageStreamIT.java
@@ -19,8 +19,10 @@ package org.dataconservancy.pass.deposit.assembler.dspace.mets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.dataconservancy.nihms.assembler.MetadataBuilder;
+import org.dataconservancy.nihms.model.DepositFile;
 import org.dataconservancy.nihms.model.DepositFileType;
 import org.dataconservancy.pass.deposit.assembler.shared.DefaultResourceBuilderFactory;
+import org.dataconservancy.pass.deposit.assembler.shared.DepositFileResource;
 import org.dataconservancy.pass.deposit.assembler.shared.MetadataBuilderImpl;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
 import org.dataconservancy.nihms.model.DepositSubmission;
@@ -53,9 +55,7 @@ public class DspaceMetsPackageStreamIT {
 
     private DspaceMetadataDomWriter metsWriter = new DspaceMetadataDomWriter(DocumentBuilderFactory.newInstance());
 
-    private List<Resource> custodialContent = Arrays.asList(
-            new ClassPathResource(this.getClass().getPackage().getName().replace(".", "/") + "/manuscript.txt"),
-            new ClassPathResource(this.getClass().getPackage().getName().replace(".", "/") + "/figure.jpg"));
+    private List<DepositFileResource> custodialContent;
 
     @Before
     public void setUp() throws Exception {
@@ -64,6 +64,25 @@ public class DspaceMetsPackageStreamIT {
         tempDir = new File(tempDir.getParent(), tempDir.getName());
         assertTrue("Unable to create directory '" + tempDir + "'", tempDir.mkdirs());
 //        tempDir.deleteOnExit();
+
+        String manuscriptLocation = this.getClass().getPackage().getName().replace(".", "/") + "/manuscript.txt";
+        String figureLocation = this.getClass().getPackage().getName().replace(".", "/") + "/figure.jpg";
+
+        DepositFile manuscript = new DepositFile();
+        manuscript.setName("manuscript.txt");
+        manuscript.setType(DepositFileType.manuscript);
+        manuscript.setLabel("Manuscript");
+        manuscript.setLocation(manuscriptLocation);
+
+        DepositFile figure = new DepositFile();
+        figure.setName("figure.jpg");
+        figure.setType(DepositFileType.figure);
+        figure.setLabel("Figure");
+        figure.setLocation(figureLocation);
+
+        custodialContent = Arrays.asList(
+                new DepositFileResource(manuscript, new ClassPathResource(manuscriptLocation)),
+                new DepositFileResource(figure, new ClassPathResource(figureLocation)));
     }
 
     @Test

--- a/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsPackageStreamTest.java
+++ b/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsPackageStreamTest.java
@@ -22,12 +22,14 @@ import org.dataconservancy.nihms.assembler.MetadataBuilder;
 import org.dataconservancy.nihms.assembler.PackageStream;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import org.dataconservancy.pass.deposit.assembler.shared.MetadataBuilderImpl;
+import org.dataconservancy.nihms.model.DepositFile;
+import org.dataconservancy.nihms.model.DepositFileType;
+import org.dataconservancy.pass.deposit.assembler.shared.DepositFileResource;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 
 import java.util.Arrays;
 import java.util.List;
@@ -49,20 +51,38 @@ public class DspaceMetsPackageStreamTest {
 
     private DspaceMetadataDomWriter metsWriter = mock(DspaceMetadataDomWriter.class);
 
-    private List<Resource> custodialContent = Arrays.asList(
-            new ClassPathResource(this.getClass().getPackage().getName().replace(".", "/") + "/manuscript.txt"),
-            new ClassPathResource(this.getClass().getPackage().getName().replace(".", "/") + "/figure.jpg"));
+    private List<DepositFileResource> custodialContent;
 
 
     @Before
     public void setUp() throws Exception {
         when(rbf.newInstance()).thenReturn(new ResourceBuilderImpl());
+
         mb.spec(SPEC_DSPACE_METS);
         mb.archive(PackageStream.ARCHIVE.ZIP);
         mb.archived(true);
         mb.compressed(true);
         mb.compression(PackageStream.COMPRESSION.ZIP);
         mb.mimeType(APPLICATION_ZIP);
+
+        String manuscriptLocation = this.getClass().getPackage().getName().replace(".", "/") + "/manuscript.txt";
+        String figureLocation = this.getClass().getPackage().getName().replace(".", "/") + "/figure.jpg";
+
+        DepositFile manuscript = new DepositFile();
+        manuscript.setName("manuscript.txt");
+        manuscript.setType(DepositFileType.manuscript);
+        manuscript.setLabel("Manuscript");
+        manuscript.setLocation(manuscriptLocation);
+
+        DepositFile figure = new DepositFile();
+        figure.setName("figure.jpg");
+        figure.setType(DepositFileType.figure);
+        figure.setLabel("Figure");
+        figure.setLocation(figureLocation);
+
+        custodialContent = Arrays.asList(
+                new DepositFileResource(manuscript, new ClassPathResource(manuscriptLocation)),
+                new DepositFileResource(figure, new ClassPathResource(figureLocation)));
     }
 
     @Test

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
@@ -22,10 +22,10 @@ import org.dataconservancy.nihms.model.DepositFile;
 import org.dataconservancy.nihms.model.DepositFileType;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractAssembler;
+import org.dataconservancy.pass.deposit.assembler.shared.DepositFileResource;
 import org.dataconservancy.pass.deposit.assembler.shared.MetadataBuilderFactory;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -64,7 +64,7 @@ public class NihmsAssembler extends AbstractAssembler {
     }
 
     @Override
-    protected PackageStream createPackageStream(DepositSubmission submission, List<Resource> custodialResources, MetadataBuilder mb, ResourceBuilderFactory rbf) {
+    protected PackageStream createPackageStream(DepositSubmission submission, List<DepositFileResource> custodialResources, MetadataBuilder mb, ResourceBuilderFactory rbf) {
 
         mb.spec(SPEC_NIHMS_NATIVE_2017_07);
         mb.archive(PackageStream.ARCHIVE.TAR);

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsZippedPackageStream.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsZippedPackageStream.java
@@ -22,6 +22,7 @@ import org.dataconservancy.nihms.model.DepositFileType;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractZippedPackageStream;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractThreadedOutputStreamWriter;
+import org.dataconservancy.pass.deposit.assembler.shared.DepositFileResource;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +47,7 @@ public class NihmsZippedPackageStream extends AbstractZippedPackageStream {
 
     private MetadataBuilder metadata;
 
-    public NihmsZippedPackageStream(DepositSubmission submission, List<org.springframework.core.io.Resource> custodialResources,
+    public NihmsZippedPackageStream(DepositSubmission submission, List<DepositFileResource> custodialResources,
                                     MetadataBuilder metadata, ResourceBuilderFactory rbf) {
         super(custodialResources, metadata, rbf);
         this.submission = submission;

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/ThreadedOutputStreamWriter.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/ThreadedOutputStreamWriter.java
@@ -20,13 +20,12 @@ import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.dataconservancy.nihms.assembler.MetadataBuilder;
 import org.dataconservancy.nihms.assembler.PackageStream;
-import org.dataconservancy.nihms.model.DepositFileType;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractThreadedOutputStreamWriter;
+import org.dataconservancy.pass.deposit.assembler.shared.DepositFileResource;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
 
 import java.io.IOException;
 import java.util.List;
@@ -46,7 +45,7 @@ class ThreadedOutputStreamWriter extends AbstractThreadedOutputStreamWriter {
 
 
     public ThreadedOutputStreamWriter(String threadName, ArchiveOutputStream archiveOut, DepositSubmission submission,
-                                      List<Resource> packageFiles, ResourceBuilderFactory rbf, MetadataBuilder metadataBuilder,
+                                      List<DepositFileResource> packageFiles, ResourceBuilderFactory rbf, MetadataBuilder metadataBuilder,
                                       StreamingSerializer manifestSerializer, StreamingSerializer metadataSerializer) {
         super(threadName, archiveOut, submission, packageFiles, rbf, metadataBuilder);
         this.manifestSerializer = manifestSerializer;
@@ -81,8 +80,9 @@ class ThreadedOutputStreamWriter extends AbstractThreadedOutputStreamWriter {
      * @return a collision-free name for the provided resource file.
      */
     @Override
-    protected String nameResource(Resource resource) {
-        return NihmsZippedPackageStream.getNonCollidingFilename(resource.getFilename(), DepositFileType.supplemental);
+    protected String nameResource(DepositFileResource resource) {
+        return NihmsZippedPackageStream.getNonCollidingFilename(super.nameResource(resource),
+                resource.getDepositFile().getType());
     }
 
 }

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsPackageStreamTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsPackageStreamTest.java
@@ -19,16 +19,17 @@ import org.apache.commons.io.IOUtils;
 import org.dataconservancy.nihms.assembler.MetadataBuilder;
 import org.dataconservancy.nihms.assembler.PackageStream;
 import org.dataconservancy.nihms.assembler.ResourceBuilder;
+import org.dataconservancy.nihms.model.DepositFile;
 import org.dataconservancy.nihms.model.DepositFileType;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import org.dataconservancy.pass.deposit.assembler.shared.MetadataBuilderImpl;
+import org.dataconservancy.pass.deposit.assembler.shared.DepositFileResource;
 import org.dataconservancy.pass.deposit.assembler.shared.ResourceBuilderFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -59,9 +60,7 @@ public class NihmsPackageStreamTest {
 
     private StreamingSerializer metadataSerializer = () -> performSilently(() -> IOUtils.toInputStream("This is the metadata", "UTF-8"));
 
-    private List<Resource> custodialContent = Arrays.asList(
-            new ClassPathResource(this.getClass().getPackage().getName().replace(".", "/") + "/manuscript.txt"),
-            new ClassPathResource(this.getClass().getPackage().getName().replace(".", "/") + "/figure.jpg"));
+    private List<DepositFileResource> custodialContent;
 
     private MetadataBuilder mb = mock(MetadataBuilder.class);
     private ResourceBuilderFactory rbf = mock(ResourceBuilderFactory.class);
@@ -72,6 +71,7 @@ public class NihmsPackageStreamTest {
     @Before
     public void setUp() throws Exception {
         when(rbf.newInstance()).thenReturn(rb);
+
         MetadataBuilder metadataBuilder = new MetadataBuilderImpl();
         metadataBuilder.spec(SPEC_NIHMS_NATIVE_2017_07);
         metadataBuilder.archive(PackageStream.ARCHIVE.TAR);
@@ -80,6 +80,24 @@ public class NihmsPackageStreamTest {
         metadataBuilder.compression(PackageStream.COMPRESSION.GZIP);
         metadataBuilder.mimeType(APPLICATION_GZIP);
 
+        String manuscriptLocation = this.getClass().getPackage().getName().replace(".", "/") + "/manuscript.txt";
+        String figureLocation = this.getClass().getPackage().getName().replace(".", "/") + "/figure.jpg";
+
+        DepositFile manuscript = new DepositFile();
+        manuscript.setName("manuscript.txt");
+        manuscript.setType(DepositFileType.manuscript);
+        manuscript.setLabel("Manuscript");
+        manuscript.setLocation(manuscriptLocation);
+
+        DepositFile figure = new DepositFile();
+        figure.setName("figure.jpg");
+        figure.setType(DepositFileType.figure);
+        figure.setLabel("Figure");
+        figure.setLocation(figureLocation);
+
+        custodialContent = Arrays.asList(
+                new DepositFileResource(manuscript, new ClassPathResource(manuscriptLocation)),
+                new DepositFileResource(figure, new ClassPathResource(figureLocation)));
     }
 
     /**

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractThreadedOutputStreamWriter.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractThreadedOutputStreamWriter.java
@@ -61,7 +61,7 @@ public abstract class AbstractThreadedOutputStreamWriter extends Thread {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractThreadedOutputStreamWriter.class);
 
-    private List<Resource> packageFiles;
+    private List<DepositFileResource> packageFiles;
 
     private AbstractThreadedOutputStreamWriter.CloseOutputstreamCallback closeStreamHandler;
 
@@ -89,7 +89,7 @@ public abstract class AbstractThreadedOutputStreamWriter extends Thread {
      *            package resources}
      */
     public AbstractThreadedOutputStreamWriter(String threadName, ArchiveOutputStream archiveOut,
-                                              DepositSubmission submission, List<Resource> packageFiles,
+                                              DepositSubmission submission, List<DepositFileResource> packageFiles,
                                               ResourceBuilderFactory rbf, MetadataBuilder metadataBuilder) {
         super(threadName);
         this.archiveOut = archiveOut;
@@ -210,7 +210,11 @@ public abstract class AbstractThreadedOutputStreamWriter extends Thread {
      * @param resource the resource
      * @return the name of the resource
      */
-    protected String nameResource(Resource resource) {
+    protected String nameResource(DepositFileResource resource) {
+        if (resource.getDepositFile() != null && resource.getDepositFile().getName() != null) {
+            return resource.getDepositFile().getName();
+        }
+
         return resource.getFilename();
     }
 

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractZippedPackageStream.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractZippedPackageStream.java
@@ -22,6 +22,7 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.dataconservancy.nihms.assembler.MetadataBuilder;
 import org.dataconservancy.nihms.assembler.PackageStream;
+import org.dataconservancy.nihms.model.DepositFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,13 +46,13 @@ public abstract class AbstractZippedPackageStream implements PackageStream {
     protected static final String ERR_CREATING_ARCHIVE_STREAM = "Error creating a %s archive output stream: %s";
     protected static final String ERR_NO_ARCHIVE_FORMAT = "No supported archive format was specified in the metadata builder";
 
-    protected List<org.springframework.core.io.Resource> custodialContent;
+    protected List<DepositFileResource> custodialContent;
 
     private MetadataBuilder metadataBuilder;
 
     private ResourceBuilderFactory rbf;
 
-    public AbstractZippedPackageStream(List<org.springframework.core.io.Resource> custodialContent,
+    public AbstractZippedPackageStream(List<DepositFileResource> custodialContent,
                                        MetadataBuilder metadataBuilder, ResourceBuilderFactory rbf) {
         this.custodialContent = custodialContent;
         this.metadataBuilder = metadataBuilder;

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/DepositFileResource.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/DepositFileResource.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.assembler.shared;
+
+import org.dataconservancy.nihms.model.DepositFile;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.lang.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.channels.ReadableByteChannel;
+
+/**
+ * A Spring {@code Resource} paired with its {@link DepositFile}, providing access to "logical" resource metadata.
+ * <p>
+ * Users of {@code DepositFileResource} may prefer the {@link #getDepositFile() DepositFile} for metadata rather than
+ * than the metadata provided by the Spring {@code Resource}.  For example, {@link Resource#getFilename()} will return
+ * a <em>URL path</em> as a resource name when the {@code Resource} is remote (i.e. implemented as {@link UrlResource})
+ * vs a <em>filesystem path</em> when the resource is local (i.e. implemented as a {@link FileSystemResource}).
+ * </p>
+ * <p>
+ * The {@link DepositFile} associated with the {@code Resource} is independent of the {@code Resource}
+ * <em>implementation</em>.  This allows the user of {@code DepositFileResource}, for example, to obtain the logical
+ * name of a resource (via {@link DepositFile#getName()}) independent of its location.
+ * </p>
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class DepositFileResource implements Resource {
+
+    private Resource resource;
+
+    private DepositFile depositFile;
+
+    public DepositFileResource(DepositFile depositFile) {
+        if (depositFile == null) {
+            throw new IllegalArgumentException("DepositFile must not be null.");
+        }
+
+        this.depositFile = depositFile;
+    }
+
+    public DepositFileResource(DepositFile depositFile, Resource resource) {
+        if (resource == null) {
+            throw new IllegalArgumentException("Spring Resource must not be null.");
+        }
+
+        if (depositFile == null) {
+            throw new IllegalArgumentException("DepositFile must not be null.");
+        }
+
+        this.resource = resource;
+        this.depositFile = depositFile;
+    }
+
+    public DepositFile getDepositFile() {
+        return depositFile;
+    }
+
+    public void setDepositFile(DepositFile depositFile) {
+        if (depositFile == null) {
+            throw new IllegalArgumentException("DepositFile must not be null.");
+        }
+        this.depositFile = depositFile;
+    }
+
+    public Resource getResource() {
+        return resource;
+    }
+
+    public void setResource(Resource resource) {
+        if (resource == null) {
+            throw new IllegalArgumentException("Spring Resource must not be null.");
+        }
+        this.resource = resource;
+    }
+
+    @Override
+    public boolean exists() {
+        assertState();
+        return resource.exists();
+    }
+
+    @Override
+    public boolean isReadable() {
+        assertState();
+        return resource.isReadable();
+    }
+
+    @Override
+    public boolean isOpen() {
+        assertState();
+        return resource.isOpen();
+    }
+
+    @Override
+    public boolean isFile() {
+        assertState();
+        return resource.isFile();
+    }
+
+    @Override
+    public URL getURL() throws IOException {
+        assertState();
+        return resource.getURL();
+    }
+
+    @Override
+    public URI getURI() throws IOException {
+        assertState();
+        return resource.getURI();
+    }
+
+    @Override
+    public File getFile() throws IOException {
+        assertState();
+        return resource.getFile();
+    }
+
+    @Override
+    public ReadableByteChannel readableChannel() throws IOException {
+        assertState();
+        return resource.readableChannel();
+    }
+
+    @Override
+    public long contentLength() throws IOException {
+        assertState();
+        return resource.contentLength();
+    }
+
+    @Override
+    public long lastModified() throws IOException {
+        assertState();
+        return resource.lastModified();
+    }
+
+    @Override
+    public Resource createRelative(String relativePath) throws IOException {
+        assertState();
+        return resource.createRelative(relativePath);
+    }
+
+    @Nullable
+    @Override
+    public String getFilename() {
+        assertState();
+        return resource.getFilename();
+    }
+
+    @Override
+    public String getDescription() {
+        assertState();
+        return resource.getDescription();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        assertState();
+        return resource.getInputStream();
+    }
+
+    private void assertState() {
+        if (this.resource == null) {
+            throw new IllegalStateException("The delegate Spring Resource is null: has setResource(Resource) been " +
+                    "called?");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "DepositFileResource{" + "resource=" + resource + ", depositFile=" + depositFile + '}';
+    }
+}


### PR DESCRIPTION
Filenames for custodial content used to be determined by Resource.getFilename(), which is problematic when the Resource is remote.  This introduces a new Resource type which carries the DepositFile alongside the Resource.  The logical filename can now be retrieved from DepositFile, instead of relying on the physical filename.