### PR TITLE
Additional handling of potential null values when processing metadata.

### DIFF
--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
@@ -77,14 +77,15 @@ abstract class ModelBuilder {
         person.setCorrespondingPi(isCoPI);
         person.setAuthor(isAuthor);
         // Available User data for which there is no place in the existing DepositMetadata.Person:
-        String username = userEntity.getUsername();
-        String displayName = userEntity.getDisplayName();
-        String affiliation = userEntity.getAffiliation();
-        String institutionalId = userEntity.getInstitutionalId();
-        String localKey = userEntity.getLocalKey();
-        String orcidId = userEntity.getOrcidId();
-        for (User.Role role : userEntity.getRoles()) {
-        }
+        // Leave commented out until this metadata is to be used.  Protect against NPEs.
+//        String username = userEntity.getUsername();
+//        String displayName = userEntity.getDisplayName();
+//        String affiliation = userEntity.getAffiliation();
+//        String institutionalId = userEntity.getInstitutionalId();
+//        String localKey = userEntity.getLocalKey();
+//        String orcidId = userEntity.getOrcidId();
+//        for (User.Role role : userEntity.getRoles()) {
+//        }
 
         return person;
     }
@@ -123,10 +124,11 @@ abstract class ModelBuilder {
         String journalTitle = getStringProperty(submissionData, "journal-title");
         metadata.getJournalMetadata().setJournalTitle(journalTitle);
 
-        String journalTitleShort = getStringProperty(submissionData, "journal-title-short");
-        String volume = getStringProperty(submissionData, "volume");
-        String issue = getStringProperty(submissionData, "issue");
-        String subjects = getStringProperty(submissionData, "subjects");
+        // Leave commented out until this metadata is to be used.  Protect against NPEs.
+//        String journalTitleShort = getStringProperty(submissionData, "journal-title-short");
+//        String volume = getStringProperty(submissionData, "volume");
+//        String issue = getStringProperty(submissionData, "issue");
+//        String subjects = getStringProperty(submissionData, "subjects");
 
         String url = getStringProperty(submissionData, "URL");
         try {
@@ -135,12 +137,13 @@ abstract class ModelBuilder {
             throw new InvalidModel(String.format("Data file '%s' contained an invalid URL.", url), e);
         }
 
-        JsonArray authors = submissionData.get("authors").getAsJsonArray();
-        for (JsonElement element : authors) {
-            JsonObject author = element.getAsJsonObject();
-            String name = getStringProperty(author, "author");
-            String orcid = getStringProperty(author, "orcid");
-        }
+        // Leave commented out until this metadata is to be used.  Protect against NPEs.
+//        JsonArray authors = submissionData.get("authors").getAsJsonArray();
+//        for (JsonElement element : authors) {
+//            JsonObject author = element.getAsJsonObject();
+//            String name = getStringProperty(author, "author");
+//            String orcid = getStringProperty(author, "orcid");
+//        }
     }
 
     private void processNihMetadata(DepositMetadata metadata, JsonObject submissionData) {
@@ -218,10 +221,11 @@ abstract class ModelBuilder {
         // The deposit data model requires a "name" - for now we use the ID.
         submission.setName(submissionEntity.getId().toString());
         // Available Submission data for which there is no place in the existing DepositSubmission:
-        Submission.Source source = submissionEntity.getSource();
-        Boolean submitted = submissionEntity.getSubmitted();
-        DateTime submittedDate = submissionEntity.getSubmittedDate();
-        Submission.AggregatedDepositStatus status = submissionEntity.getAggregatedDepositStatus();
+        // Leave commented out until this metadata is to be used.  Protect against NPEs.
+//        Submission.Source source = submissionEntity.getSource();
+//        Boolean submitted = submissionEntity.getSubmitted();
+//        DateTime submittedDate = submissionEntity.getSubmittedDate();
+//        Submission.AggregatedDepositStatus status = submissionEntity.getAggregatedDepositStatus();
 
         // Data from the Submission's user resource
         User userEntity = (User)entities.get(submissionEntity.getUser());
@@ -238,10 +242,11 @@ abstract class ModelBuilder {
         }
         // Available Publication data for which there is no place in the existing deposit model:
         // Some of these properties are ignored because they are overwritten by the metadata, below.
-        String publicationAbstract = publicationEntity.getPublicationAbstract();
-        String pmid = publicationEntity.getPmid();
-        String volume = publicationEntity.getVolume();
-        String issue = publicationEntity.getIssue();
+        // Leave commented out until this metadata is to be used.  Protect against NPEs.
+//        String publicationAbstract = publicationEntity.getPublicationAbstract();
+//        String pmid = publicationEntity.getPmid();
+//        String volume = publicationEntity.getVolume();
+//        String issue = publicationEntity.getIssue();
 
         Journal journalEntity = (Journal)entities.get(publicationEntity.getJournal());
         //journal.setJournalTitle(journalEntity.getName());
@@ -254,7 +259,8 @@ abstract class ModelBuilder {
         // Is the model's ID the nlmta value?
         //journal.setJournalId(journalEntity.getNlmta());
         // Available data for which there is no place in the existing deposit model:
-        PmcParticipation journalParticipation = journalEntity.getPmcParticipation();
+        // Leave commented out until this metadata is to be used.  Protect against NPEs.
+//        PmcParticipation journalParticipation = journalEntity.getPmcParticipation();
 
         // Publishers are not currently used in deposits, and may be missing from Journal resources.
         /*
@@ -277,9 +283,10 @@ abstract class ModelBuilder {
         for (URI repositoryUri : submissionEntity.getRepositories()) {
             Repository repositoryEntity = (Repository)entities.get(repositoryUri);
             // Available Repository data for which there is no place in the existing deposit model:
-            String repoName = repositoryEntity.getName();
-            String repoDescription = repositoryEntity.getDescription();
-            URI repoUrl = repositoryEntity.getUrl();
+            // Leave commented out until this metadata is to be used.  Protect against NPEs.
+//            String repoName = repositoryEntity.getName();
+//            String repoDescription = repositoryEntity.getDescription();
+//            URI repoUrl = repositoryEntity.getUrl();
             // (member formSchema should not be needed)
         }
 
@@ -287,13 +294,14 @@ abstract class ModelBuilder {
         for (URI grantUri : submissionEntity.getGrants()) {
             Grant grantEntity = (Grant)entities.get(grantUri);
             // Available data for which there is no place in the existing model:
-            String awardNum = grantEntity.getAwardNumber();
-            Grant.AwardStatus awardStatus = grantEntity.getAwardStatus();
-            String projectLocalKey = grantEntity.getLocalKey();
-            String projectName = grantEntity.getProjectName();
-            DateTime awardDate = grantEntity.getAwardDate();
-            DateTime startDate = grantEntity.getStartDate();
-            DateTime endDate = grantEntity.getEndDate();
+            // Leave commented out until this metadata is to be used.  Protect against NPEs.
+//            String awardNum = grantEntity.getAwardNumber();
+//            Grant.AwardStatus awardStatus = grantEntity.getAwardStatus();
+//            String projectLocalKey = grantEntity.getLocalKey();
+//            String projectName = grantEntity.getProjectName();
+//            DateTime awardDate = grantEntity.getAwardDate();
+//            DateTime startDate = grantEntity.getStartDate();
+//            DateTime endDate = grantEntity.getEndDate();
 
             // Data from the Primary Funder and its Policy resources
 //            Funder primaryFunderEntity = (Funder)entities.get(grantEntity.getPrimaryFunder());

--- a/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -20,6 +20,7 @@ import org.dataconservancy.nihms.model.DepositMetadata;
 import org.dataconservancy.nihms.model.DepositSubmission;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import org.dataconservancy.pass.model.PassEntity;
@@ -41,6 +42,7 @@ public class FilesystemModelBuilderTest {
     private DepositSubmission submission;
     private FilesystemModelBuilder underTest = new FilesystemModelBuilder();
     private String SAMPLE_SUBMISSION_RESOURCE = "SampleSubmissionData.json";
+    private String SAMPLE_SUBMISSION_RESOURCE_NULL_FIELDS = "/SampleSubmissionData-with-null-common-md-fields.json";
 
     @Before
     public void setup() throws Exception{
@@ -92,4 +94,15 @@ public class FilesystemModelBuilderTest {
         assertEquals("http://dx.doi.org/10.1039/c7fo01251a", manuscriptMetadata.getManuscriptUrl().toString());
     }
 
+    @Test
+    public void buildWithNullValues() throws Exception {
+        // Create submission data from sample data file with null values
+        URL sampleDataUrl = this.getClass().getResource(SAMPLE_SUBMISSION_RESOURCE_NULL_FIELDS);
+        assertNotNull("Could not resolve classpath resource " + SAMPLE_SUBMISSION_RESOURCE_NULL_FIELDS, sampleDataUrl);
+        submission = underTest.build(sampleDataUrl.getPath());
+
+        assertNotNull(submission);
+        assertNull(submission.getMetadata().getManuscriptMetadata().getMsAbstract());
+        assertNull(submission.getMetadata().getManuscriptMetadata().getManuscriptUrl());
+    }
 }

--- a/fedora-builder/src/test/resources/SampleSubmissionData-with-null-common-md-fields.json
+++ b/fedora-builder/src/test/resources/SampleSubmissionData-with-null-common-md-fields.json
@@ -1,0 +1,149 @@
+[
+  {
+    "metadata" : "[{\"id\": \"JScholarship\", \"data\": { \"under-embargo\": \"true\", \"Embargo-end-date\": \"09/25/19\", \"embargo\": \"NON-EXCLUSIVE LICENSE FOR USE OF MATERIALS This non-exclusive license defines the terms for the deposit of Materials in all formats into the digital repository of materials collected, preserved and made available through the Johns Hopkins Digital Repository, JScholarship. The Contributor hereby grants to Johns Hopkins a royalty free, non-exclusive worldwide license to use, re-use, display, distribute, transmit, publish, re-publish or copy the Materials, either digitally or in print, or in any other medium, now or hereafter known, for the purpose of including the Materials hereby licensed in the collection of materials in the Johns Hopkins Digital Repository for educational use worldwide. In some cases, access to content may be restricted according to provisions established in negotiation with the copyright holder. This license shall not authorize the commercial use of the Materials by Johns Hopkins or any other person or organization, but such Materials shall be restricted to non-profit educational use. Persons may apply for commercial use by contacting the copyright holder. Copyright and any other intellectual property right in or to the Materials shall not be transferred by this agreement and shall remain with the Contributor, or the Copyright holder if different from the Contributor. Other than this limited license, the Contributor or Copyright holder retains all rights, title, copyright and other interest in the images licensed. If the submission contains material for which the Contributor does not hold copyright, the Contributor represents that s/he has obtained the permission of the Copyright owner to grant Johns Hopkins the rights required by this license, and that such third-party owned material is clearly identified and acknowledged within the text or content of the submission. If the submission is based upon work that has been sponsored or supported by an agency or organization other than Johns Hopkins, the Contributor represents that s/he has fulfilled any right of review or other obligations required by such contract or agreement. Johns Hopkins will not make any alteration, other than as allowed by this license, to your submission. This agreement embodies the entire agreement of the parties. No modification of this agreement shall be of any effect unless it is made in writing and signed by all of the parties to the agreement.\", \"agreement-to-embargo\": \"true\" } }, { \"id\": \"common\", \"data\": { \"title\": \"Specific protein supplementation using soya, casein or whey differentially affects regional gut growth and luminal growth factor bioactivity in rats; implications for the treatment of gut injury and stimulating repair\", \"journal-title\": \"Food Funct.\", \"authors\": [ { \"author\": \"Tania Marchbank\", \"orcid\": \"http://orcid.org/0000-0003-2076-9098\" }, { \"author\": \"Nikki Mandir\" }, { \"author\": \"Denis Calnan\" }, { \"author\": \"Robert A. Goodlad\" }, { \"author\": \"Theo Podas\" }, { \"author\": \"Raymond J. Playford\", \"orcid\": \"http://orcid.org/0000-0003-1235-8504\" } ] } }, { \"id\": \"nih\", \"data\": { \"journal-NLMTA-ID\": \"TD452689\", \"ISSN\": \"2042-6496,2042-650X\" } } ]",
+    "source" : "pass",
+    "submitted" : true,
+    "submittedDate" : "2017-06-02T00:00:00.000Z",
+    "aggregatedDepositStatus" : "not-started",
+    "publication" : "fake:publication1",
+    "repositories" : [ "fake:repository1" ],
+    "user" : "fake:user1",
+    "grants" : [ "fake:grant1" ],
+    "@id" : "fake:submission1",
+    "@type" : "Submission"
+  },
+  {
+    "title" : "This is the first submission",
+    "abstract" : "This is a great paper!",
+    "doi" : "abcdef",
+    "pmid" : "fedcba",
+    "journal" : "fake:journal1",
+    "volume" : "123",
+    "issue" : "May 2015",
+    "@id" : "fake:publication1",
+    "@type" : "Publication"
+  },
+  {
+    "name" : "AAPS PharmSci",
+    "issns" : [ "issn123", "issn456" ],
+    "nlmta" : "AAPS PharmSci",
+    "pmcParticipation" : "A",
+    "publisher" : "",
+    "@id" : "fake:journal1",
+    "@type" : "Journal"
+  },
+  {
+    "name" : "PubMed Central",
+    "description" : "Contains lots of medical papers",
+    "url" : "http://example.com",
+    "formSchema" : "{}",
+    "@id" : "fake:repository1",
+    "@type" : "Repository"
+  },
+  {
+    "awardNumber" : "R01EY026617",
+    "awardStatus" : "active",
+    "localKey" : "112233",
+    "projectName" : "Optimal magnification and oculomotor strategies in low vision patients",
+    "awardDate" : "2017-06-01T00:00:00.000Z",
+    "startDate" : "2017-05-01T00:00:00.000Z",
+    "endDate" : "2018-06-01T00:00:00.000Z",
+    "primaryFunder" : "fake:funder1",
+    "directFunder" : "fake:funder2",
+    "pi" : "fake:user2",
+    "coPis" : [ "fake:user3" ],
+    "@id" : "fake:grant1",
+    "@type" : "Grant"
+  },
+  {
+    "name" : "National Eye Institute",
+    "url" : "http://example.com/eyeguys",
+    "localKey" : "aabbcc",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder1",
+    "@type" : "Funder"
+  },
+  {
+    "title" : "Be Nice to People With Eyes",
+    "description" : "We only have eyes for you.",
+    "policyUrl" : "http://theeyeshaveit.com/policy",
+    "repositories" : [ "fake:repository1" ],
+    "institution" : "fake:institution1",
+    "funder" : "fake:funder1",
+    "@id" : "fake:policy1",
+    "@type" : "Policy"
+  },
+  {
+    "name" : "International Eye Institute",
+    "url" : "http://example.com/othereyeguys",
+    "localKey" : "ddeeff",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder2",
+    "@type" : "Funder"
+  },
+  {
+    "username" : "bobsmith",
+    "firstName" : "Robert",
+    "middleName" : "Cure",
+    "lastName" : "Smith",
+    "displayName" : "Bob Smith",
+    "email" : "bobsmith@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "bs1",
+    "localKey" : "key123",
+    "orcidId" : "orcid123",
+    "roles" : [ "submitter", "admin" ],
+    "@id" : "fake:user1",
+    "@type" : "User"
+  },
+  {
+    "username" : "suzyv",
+    "firstName" : "Suzanne",
+    "middleName" : "X",
+    "lastName" : "Vega",
+    "displayName" : "Suzanne Vega",
+    "email" : "suzannev@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "sxv3",
+    "localKey" : "keyabc",
+    "orcidId" : "orc456",
+    "roles" : [ "submitter" ],
+    "@id" : "fake:user2",
+    "@type" : "User"
+  },
+  {
+    "username" : "johndoe",
+    "firstName" : "John",
+    "middleName" : "Nobody",
+    "lastName" : "Doe",
+    "displayName" : "John Doe",
+    "email" : "jd@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "jd123",
+    "localKey" : "keyabc123",
+    "orcidId" : "orc789",
+    "roles" : [ "admin" ],
+    "@id" : "fake:user3",
+    "@type" : "User"
+  },
+  {
+    "name" : "test_image",
+    "uri" : "classpath:/org/dataconservancy/nihms/builder/fs/dektol.jpg",
+    "description" : "A logo to test supplemental type",
+    "fileRole" : "supplemental",
+    "mimeType" : "image/png",
+    "submission" : "fake:submission1",
+    "@id" : "fake:file1",
+    "@type" : "File"
+  },
+  {
+    "name" : "test_pdf",
+    "uri" : "classpath:/org/dataconservancy/nihms/builder/fs/ilford_film_processing_chart.pdf",
+    "description" : "PDF hype to test manuscript type",
+    "fileRole" : "manuscript",
+    "mimeType" : "application/pdf",
+    "submission" : "fake:submission1",
+    "@id" : "fake:file2",
+    "@type" : "File"
+  }
+]


### PR DESCRIPTION
1. Moves to the use of `Optional` providing nicer idioms (in most cases) for processing potentially `null` values
    * Note that `null` semantics are maintained when processing `boolean` values: `ifPresent` will tell you whether a `boolean` value is present, but the value itself still needs to be tested for `true` or `false`
2. Comments out code that parses JSON where the parsed value is not used.  Parsing is a chance for NPEs to occur, and if we aren't using the result, lets just not parse the JSON.

Closes issue #92 