### PR TITLE
File label

### DIFF
--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
@@ -41,9 +41,9 @@ public class DepositFileLabelMaker {
 
     private static final Set<DepositFileType> types = new HashSet<>(Arrays.asList(labeledTypes));
 
-    private static Map<DepositFileType, Set<String>> usedFileLabels = createLabelMap(types);
+    private static Map<DepositFileType, Set<String>> usedFileLabels = createLabelMap();
 
-    private static  Map<DepositFileType, Set<String>> createLabelMap(Set<DepositFileType> types) {
+    private static  Map<DepositFileType, Set<String>> createLabelMap() {
         Map<DepositFileType, Set<String>> labelMap = new HashMap<>();
         for (DepositFileType fileType : types) {
             labelMap.put(fileType, new HashSet<>());

--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
@@ -29,7 +29,7 @@ import java.util.Set;
  *
  * We are supporting Labels only for all file types which are required to have them.
  *
- * From page 1 the NIHMS Bulk Submission Speccification for Funding Agencies, July 2017
+ * From page 1 the NIHMS Bulk Submission Specification for Funding Agencies, July 2017
  *
  *  "{label} is a label to differentiate between files of one {file_type} in the system.
  *   This field is required for figure, table, and supplement file types.

--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.nihms.builder.fs;
+
+import org.dataconservancy.nihms.model.DepositFileType;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A utility class for generating unique labels for manifest entries for {@code DepositFile}s.
+ *
+ * @author jrm@jhu.edu
+ */
+
+public class DepositFileLabelMaker {
+
+    //these are the types for which we will supply labels
+    private static final DepositFileType[] labeledTypes = new DepositFileType[] {
+            DepositFileType.figure,
+            DepositFileType.supplemental,
+            DepositFileType.table
+    };
+
+    private static final Set<DepositFileType> types = new HashSet<>(Arrays.asList(labeledTypes));
+
+    private static Map<DepositFileType, Set<String>> usedFileLabels = createLabelMap(types);
+
+    private static  Map<DepositFileType, Set<String>> createLabelMap(Set<DepositFileType> types) {
+        Map<DepositFileType, Set<String>> labelMap = new HashMap<>();
+        for (DepositFileType fileType : types) {
+            labelMap.put(fileType, new HashSet<>());
+        }
+        return labelMap;
+    }
+
+    /**
+     * Return a unique label for a {@code }DepositFile}. If the type of file is not to be labeled, return an empty string.
+     *
+     * @param type the {@code DepositFileType} of the {@code DepositFile} requesting a label
+     * @param description the user-supplied description of the file
+     * @return the type-unique file label if the type is to be labeled, an empty string otherwise.
+     */
+    public String label(DepositFileType type, String description) {
+
+        if (!types.contains(type)) {
+            return "";
+        }
+
+        //we need a label. do we have a usable description? if not, label stem will be the type string
+        boolean generic = description == null || description.replaceAll("\\s", "").length() == 0;
+        String label = generic ? type.toString(): description;
+        label = label.replaceAll("\t", " ").trim();//tabs have semantic meaning in manifest file
+
+        String firstTry = generic ? label + "-1" : label;
+        if (!usedFileLabels.get(type).contains(firstTry)) {
+            usedFileLabels.get(type).add(firstTry);
+            return firstTry;
+        }
+
+        //our first try is already used, let's generate a free one
+        int i = generic ? 2 : 1;//optimization :-)
+        while (usedFileLabels.get(type).contains(label + "-" + Integer.toString(i))) {
+            i++;
+        }
+        label = label + "-" + Integer.toString(i);
+        usedFileLabels.get(type).add(label);
+        return label;
+    }
+}

--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
@@ -52,7 +52,7 @@ public class DepositFileLabelMaker {
     }
 
     /**
-     * Return a unique label for a {@code }DepositFile}. If the type of file is not to be labeled, return an empty string.
+     * Return a unique label for a {@code DepositFile}. If the type of file is not to be labeled, return an empty string.
      *
      * @param type the {@code DepositFileType} of the {@code DepositFile} requesting a label
      * @param description the user-supplied description of the file

--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaker.java
@@ -27,6 +27,15 @@ import java.util.Set;
 /**
  * A utility class for generating unique labels for manifest entries for {@code DepositFile}s.
  *
+ * We are supporting Labels only for all file types which are required to have them.
+ *
+ * From page 1 the NIHMS Bulk Submission Speccification for Funding Agencies, July 2017
+ *
+ *  "{label} is a label to differentiate between files of one {file_type} in the system.
+ *   This field is required for figure, table, and supplement file types.
+ *  {label} is used to identify files sent,such as 2a, 2b, and so on.
+ *  In the case of supplemental files, the string supplied here will be used as text for a hyperlink in the PMC manuscript.
+ *
  * @author jrm@jhu.edu
  */
 

--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
@@ -353,6 +353,7 @@ abstract class ModelBuilder {
         ArrayList<DepositFile> files = new ArrayList<>();
         submission.setFiles(files);
         manifest.setFiles(files);
+        DepositFileLabelMaker labelMaker = new DepositFileLabelMaker();
 
         for (URI key : entities.keySet()) {
             PassEntity entity = entities.get(key);
@@ -365,7 +366,7 @@ abstract class ModelBuilder {
                     depositFile.setLocation(file.getUri().toString());
                     // TODO - The client model currently only has "manuscript" and "supplemental" roles.
                     depositFile.setType(DepositFileType.valueOf(file.getFileRole().name().toLowerCase()));
-                    depositFile.setLabel(""); // TODO - What value should this take?
+                    depositFile.setLabel(labelMaker.label(depositFile.getType(), file.getDescription()));
                     files.add(depositFile);
                 }
             }

--- a/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMakerTest.java
+++ b/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMakerTest.java
@@ -21,8 +21,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class DepositFileLabelMaketTest {
-
+public class DepositFileLabelMakerTest {
 
     @Test
     public void labelTest() {

--- a/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaketTest.java
+++ b/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/DepositFileLabelMaketTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.nihms.builder.fs;
+
+import org.dataconservancy.nihms.model.DepositFileType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DepositFileLabelMaketTest {
+
+
+    @Test
+    public void labelTest() {
+        DepositFileLabelMaker underTest = new DepositFileLabelMaker();
+
+        String label = underTest.label(DepositFileType.figure, null);
+        assertEquals("figure-1", label);
+
+        label = underTest.label(DepositFileType.figure, null);
+        assertEquals("figure-2", label);
+
+        label = underTest.label(DepositFileType.figure, "   ");
+        assertEquals("figure-3", label);
+
+        label = underTest.label(DepositFileType.supplemental, "figure-1");
+        assertEquals("figure-1", label);
+
+        label = underTest.label(DepositFileType.manuscript, "Moo Cows in the Pasture");
+        assertEquals("", label);
+
+        label = underTest.label(DepositFileType.figure, "Spotted Cows");
+        assertEquals("Spotted Cows", label);
+
+        label = underTest.label(DepositFileType.figure, "Spotted Cows");
+        assertEquals("Spotted Cows-1", label);
+
+        label = underTest.label(DepositFileType.figure, "Spotted Cows     ");
+        assertEquals("Spotted Cows-2", label);
+
+        label = underTest.label(DepositFileType.figure, "Spotted Cows-2");
+        assertEquals("Spotted Cows-2-1", label);
+
+        label = underTest.label(DepositFileType.table, "table");
+        assertEquals("table", label);
+
+        label = underTest.label(DepositFileType.table, "table-1");
+        assertEquals("table-1", label);
+
+        label = underTest.label(DepositFileType.table, "");
+        assertEquals("table-2", label);
+
+    }
+}

--- a/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -95,8 +95,10 @@ public class FilesystemModelBuilderTest {
         assertEquals("http://dx.doi.org/10.1039/c7fo01251a", manuscriptMetadata.getManuscriptUrl().toString());
 
         //test that the DepositFileLabelMaker is being called to supply the file labels
-        String label = submission.getManifest().getFiles().get(0).getLabel();
-        assertTrue(label.endsWith(" type")); //both file descriptions in the json file are required to have labels, end with this
+        String label = submission.getManifest().getFiles().get(0).getLabel();//the image file - label required
+        assertEquals("A logo to test supplemental type", label);
+        label = submission.getManifest().getFiles().get(1).getLabel();//the manuscript file - no label
+        assertEquals("", label);
     }
 
     @Test

--- a/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -97,7 +97,7 @@ public class FilesystemModelBuilderTest {
         //test that the DepositFileLabelMaker is being called to supply the file labels
         String label = submission.getManifest().getFiles().get(0).getLabel();//the image file - label required
         assertEquals("A logo to test supplemental type", label);
-        label = submission.getManifest().getFiles().get(1).getLabel();//the manuscript file - no label
+        label = submission.getManifest().getFiles().get(1).getLabel();//the manuscript file - empty label
         assertEquals("", label);
     }
 

--- a/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -21,6 +21,7 @@ import org.dataconservancy.nihms.model.DepositSubmission;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.dataconservancy.pass.model.PassEntity;
@@ -92,6 +93,10 @@ public class FilesystemModelBuilderTest {
 
         DepositMetadata.Manuscript manuscriptMetadata = submission.getMetadata().getManuscriptMetadata();
         assertEquals("http://dx.doi.org/10.1039/c7fo01251a", manuscriptMetadata.getManuscriptUrl().toString());
+
+        //test that the DepositFileLabelMaker is being called to supply the file labels
+        String label = submission.getManifest().getFiles().get(0).getLabel();
+        assertTrue(label.endsWith(" type")); //both file descriptions in the json file are required to have labels, end with this
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <scp.port>22</scp.port>
 
         <maven.compiler.plugin.version>2.5.1</maven.compiler.plugin.version>


### PR DESCRIPTION
provide a DepositFileLabelMaker class to generate and/or remediate manifest file labels for the NIH manifest file

adjust ModelBuilder class to use the label() method in  this class to setLabel() on DepositFiles

set project.reporting.outptEncoding entry to UTF-8 in top level pom