### PR TITLE
Updates assembler ITs to be more robust

### DIFF
--- a/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsAssemblerIT.java
+++ b/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsAssemblerIT.java
@@ -37,7 +37,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.dataconservancy.nihms.assembler.nihmsnative.NihmsAssembler.SPEC_NIHMS_NATIVE_2017_07;
 import static org.dataconservancy.pass.deposit.DepositTestUtil.asList;
+import static org.dataconservancy.pass.deposit.assembler.dspace.mets.DspaceMetsAssembler.APPLICATION_ZIP;
+import static org.dataconservancy.pass.deposit.assembler.dspace.mets.DspaceMetsAssembler.SPEC_DSPACE_METS;
 import static org.dataconservancy.pass.deposit.assembler.dspace.mets.XMLConstants.METS_CHECKSUM;
 import static org.dataconservancy.pass.deposit.assembler.dspace.mets.XMLConstants.METS_CHECKSUM_TYPE;
 import static org.dataconservancy.pass.deposit.assembler.dspace.mets.XMLConstants.METS_FILE;
@@ -75,6 +78,15 @@ public class DspaceMetsAssemblerIT extends BaseAssemblerIT {
     protected DspaceMetsAssembler assemblerUnderTest() {
         return new DspaceMetsAssembler(mbf, rbf,
                     new DspaceMetadataDomWriter(DocumentBuilderFactory.newInstance()));
+    }
+
+    @Override
+    protected void verifyStreamMetadata(PackageStream.Metadata metadata) {
+        assertEquals(PackageStream.COMPRESSION.GZIP, metadata.compression());
+        assertEquals(PackageStream.ARCHIVE.TAR, metadata.archive());
+        assertTrue(metadata.archived());
+        assertEquals(SPEC_DSPACE_METS, metadata.spec());
+        assertEquals(APPLICATION_ZIP, metadata.mimeType());
     }
 
     /**

--- a/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsAssemblerIT.java
+++ b/dspace-mets-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/dspace/mets/DspaceMetsAssemblerIT.java
@@ -82,8 +82,8 @@ public class DspaceMetsAssemblerIT extends BaseAssemblerIT {
 
     @Override
     protected void verifyStreamMetadata(PackageStream.Metadata metadata) {
-        assertEquals(PackageStream.COMPRESSION.GZIP, metadata.compression());
-        assertEquals(PackageStream.ARCHIVE.TAR, metadata.archive());
+        assertEquals(PackageStream.COMPRESSION.ZIP, metadata.compression());
+        assertEquals(PackageStream.ARCHIVE.ZIP, metadata.archive());
         assertTrue(metadata.archived());
         assertEquals(SPEC_DSPACE_METS, metadata.spec());
         assertEquals(APPLICATION_ZIP, metadata.mimeType());

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
@@ -33,20 +33,6 @@ import java.util.List;
 @Component
 public class NihmsAssembler extends AbstractAssembler {
 
-    private static final String ERR_MAPPING_LOCATION = "Unable to resolve the location of a submitted file ('%s') to a Spring Resource type.";
-
-    private static final String FILE_PREFIX = "file:";
-
-    private static final String CLASSPATH_PREFIX = "classpath:";
-
-    private static final String WILDCARD_CLASSPATH_PREFIX = "classpath*:";
-
-    private static final String HTTP_PREFIX = "http:";
-
-    private static final String HTTPS_PREFIX = "https:";
-
-    // TODO: find a better place for these constants.
-
     /**
      * Package specification URI identifying the NIHMS native packaging spec, as specified by their 07/2017
      * bulk publishing pdf.
@@ -64,8 +50,9 @@ public class NihmsAssembler extends AbstractAssembler {
     }
 
     @Override
-    protected PackageStream createPackageStream(DepositSubmission submission, List<DepositFileResource> custodialResources, MetadataBuilder mb, ResourceBuilderFactory rbf) {
-
+    protected PackageStream createPackageStream(DepositSubmission submission,
+                                                List<DepositFileResource> custodialResources, MetadataBuilder mb,
+                                                ResourceBuilderFactory rbf) {
         mb.spec(SPEC_NIHMS_NATIVE_2017_07);
         mb.archive(PackageStream.ARCHIVE.TAR);
         mb.archived(true);

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssemblerIT.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssemblerIT.java
@@ -17,6 +17,7 @@ package org.dataconservancy.nihms.assembler.nihmsnative;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
+import org.dataconservancy.nihms.assembler.PackageStream;
 import org.dataconservancy.nihms.model.DepositMetadata.Person;
 import org.dataconservancy.pass.deposit.assembler.shared.AbstractAssembler;
 import org.dataconservancy.pass.deposit.assembler.shared.BaseAssemblerIT;
@@ -33,6 +34,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.dataconservancy.nihms.assembler.nihmsnative.NihmsAssembler.APPLICATION_GZIP;
+import static org.dataconservancy.nihms.assembler.nihmsnative.NihmsAssembler.SPEC_NIHMS_NATIVE_2017_07;
 import static org.dataconservancy.nihms.assembler.nihmsnative.NihmsZippedPackageStream.REMEDIATED_FILE_PREFIX;
 import static org.dataconservancy.pass.deposit.DepositTestUtil.asList;
 import static org.junit.Assert.assertEquals;
@@ -68,6 +71,15 @@ public class NihmsAssemblerIT extends BaseAssemblerIT {
     @Override
     protected AbstractAssembler assemblerUnderTest() {
         return new NihmsAssembler(mbf, rbf);
+    }
+
+    @Override
+    protected void verifyStreamMetadata(PackageStream.Metadata metadata) {
+        assertEquals(PackageStream.COMPRESSION.GZIP, metadata.compression());
+        assertEquals(PackageStream.ARCHIVE.TAR, metadata.archive());
+        assertTrue(metadata.archived());
+        assertEquals(SPEC_NIHMS_NATIVE_2017_07, metadata.spec());
+        assertEquals(APPLICATION_GZIP, metadata.mimeType());
     }
 
     /**

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractZippedPackageStream.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractZippedPackageStream.java
@@ -22,7 +22,6 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.dataconservancy.nihms.assembler.MetadataBuilder;
 import org.dataconservancy.nihms.assembler.PackageStream;
-import org.dataconservancy.nihms.model.DepositFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,9 +94,9 @@ public abstract class AbstractZippedPackageStream implements PackageStream {
         ArchiveOutputStream archiveOut;
         PackageStream.Metadata metadata = metadata();
 
-        if(metadata.archive().equals(TAR)) {
+        if (metadata.archive().equals(TAR)) {
             try {
-                if(metadata.compression().equals(COMPRESSION.GZIP)) {
+                if (metadata.compression().equals(COMPRESSION.GZIP)) {
                     archiveOut = new TarArchiveOutputStream(new GzipCompressorOutputStream(pipedOut));
                 } else {
                     archiveOut = new TarArchiveOutputStream(pipedOut);

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/BaseAssemblerIT.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/BaseAssemblerIT.java
@@ -211,7 +211,7 @@ public abstract class BaseAssemblerIT {
                 ext.append(".gz");
                 break;
             case BZIP2:
-                ext.append("bzip");
+                ext.append(".bzip");
                 break;
         }
 

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/BaseAssemblerIT.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/BaseAssemblerIT.java
@@ -195,7 +195,27 @@ public abstract class BaseAssemblerIT {
      * @throws IOException if there is an error saving the package
      */
     protected File savePackage(PackageStream stream) throws IOException {
-        File tmpOut = tmpFile(this.getClass(), testName, ".zip");
+        StringBuilder ext = new StringBuilder();
+
+        switch (stream.metadata().archive()) {
+            case TAR:
+                ext.append(".tar");
+                break;
+            case ZIP:
+                ext.append(".zip");
+                break;
+        }
+
+        switch (stream.metadata().compression()) {
+            case GZIP:
+                ext.append(".gz");
+                break;
+            case BZIP2:
+                ext.append("bzip");
+                break;
+        }
+
+        File tmpOut = tmpFile(this.getClass(), testName, ext.toString());
 
         try (InputStream in = stream.open()) {
             Files.copy(in, tmpOut.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/BaseAssemblerIT.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/BaseAssemblerIT.java
@@ -134,6 +134,8 @@ public abstract class BaseAssemblerIT {
 
         File packageArchive = savePackage(stream);
 
+        verifyStreamMetadata(stream.metadata());
+
         extractPackage(packageArchive, stream.metadata().archive(), stream.metadata().compression());
     }
 
@@ -256,4 +258,11 @@ public abstract class BaseAssemblerIT {
      * @return the {@code AbstractAssembler} under test
      */
     protected abstract AbstractAssembler assemblerUnderTest();
+
+    /**
+     * To be implemented by sub-classes: must verify expected values found in the {@link PackageStream.Metadata}.
+     *
+     * @param metadata the package stream metadata
+     */
+    protected abstract void verifyStreamMetadata(PackageStream.Metadata metadata);
 }


### PR DESCRIPTION
* Adds additional assertions about expected `PackageStream.Metadata`.
* Provides proper filename extensions for packages generated buy the ITs.