### PR TITLE
Update components and support configuration by `ACTIVEMQ_BROKER_URI`

### DIFF
--- a/deposit-messaging/src/main/resources/application.properties
+++ b/deposit-messaging/src/main/resources/application.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-spring.activemq.broker-url=tcp://${fcrepo.host:localhost}:${fcrepo.jms.port:61616}
+spring.activemq.broker-url=${activemq.broker.uri:tcp://${fcrepo.host:localhost}:${fcrepo.jms.port:61616}}
 spring.jms.listener.acknowledge-mode=client
 spring.jms.listener.concurrency=4
 spring.jms.template.default-destination=deposit

--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
         <tika.version>1.17</tika.version>
         <pass-client.version>0.3.3-SNAPSHOT</pass-client.version>
 
-        <docker.fcrepo.version>oapass/fcrepo:4.7.5-2.2-SNAPSHOT-3</docker.fcrepo.version>
-        <docker.indexer.version>oapass/indexer:0.0.10-2.2-SNAPSHOT</docker.indexer.version>
+        <docker.fcrepo.version>oapass/fcrepo:4.7.5-2.2-SNAPSHOT-5</docker.fcrepo.version>
+        <docker.indexer.version>oapass/indexer:0.0.10-2.2-SNAPSHOT-1</docker.indexer.version>
         <docker.elasticsearch.version>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</docker.elasticsearch.version>
 
         <!-- TODO properly tag these images -->


### PR DESCRIPTION
Upgrade to fcrepo:4.7.5-2.2-SNAPSHOT-5 (from -3) and indexer:0.0.10-2.2-SNAPSHOT-1 (from 0.0.10-2.2-SNAPSHOT).  

Updates the `spring.activemq.broker-url` application property to be set to the value of `activemq.broker.uri` or to `${fcrepo.host:localhost}:${fcrepo.jms.port:61616}` if the value for `activemq.broker.uri` is missing.