### PR TITLE
Insure that a DepositSubmission has Files before processing it.

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/PassUserSubmittedPolicy.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/PassUserSubmittedPolicy.java
@@ -66,9 +66,9 @@ public class PassUserSubmittedPolicy implements SubmissionPolicy {
             return false;
         }
 
-        // Allow FAILED and NOT_STARTED Submissions to be processed.
-        if (submission.getAggregatedDepositStatus() != Submission.AggregatedDepositStatus.NOT_STARTED &&
-                submission.getAggregatedDepositStatus() != Submission.AggregatedDepositStatus.FAILED) {
+        // Currently we dis-allow FAILED Submissions; the SubmissionProcessor is not capable of "re-processing"
+        // failures.
+        if (submission.getAggregatedDepositStatus() != Submission.AggregatedDepositStatus.NOT_STARTED) {
             LOG.debug(">>>> Submission {} will not be accepted for processing: status = {}",
                     submission.getId(), submission.getAggregatedDepositStatus());
             return false;

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/PassUserSubmittedPolicy.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/policy/PassUserSubmittedPolicy.java
@@ -66,7 +66,9 @@ public class PassUserSubmittedPolicy implements SubmissionPolicy {
             return false;
         }
 
-        if (submission.getAggregatedDepositStatus() != Submission.AggregatedDepositStatus.NOT_STARTED) {
+        // Allow FAILED and NOT_STARTED Submissions to be processed.
+        if (submission.getAggregatedDepositStatus() != Submission.AggregatedDepositStatus.NOT_STARTED &&
+                submission.getAggregatedDepositStatus() != Submission.AggregatedDepositStatus.FAILED) {
             LOG.debug(">>>> Submission {} will not be accepted for processing: status = {}",
                     submission.getId(), submission.getAggregatedDepositStatus());
             return false;

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
@@ -41,17 +41,12 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 
 import java.net.URI;
-import java.util.Collection;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static java.lang.Integer.toHexString;
 import static java.lang.System.identityHashCode;
-import static org.dataconservancy.pass.deposit.messaging.service.DepositUtil.ackMessage;
 import static org.dataconservancy.pass.deposit.messaging.service.DepositUtil.toDepositWorkerContext;
 import static org.dataconservancy.pass.model.Submission.AggregatedDepositStatus.IN_PROGRESS;
-import static org.dataconservancy.pass.model.Submission.AggregatedDepositStatus.NOT_STARTED;
 
 /**
  * Processes an incoming {@code Submission} by composing and submitting a {@link DepositTask} for execution.

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
@@ -131,7 +131,7 @@ public class SubmissionProcessor implements Consumer<Submission> {
                     accepted &= ds.getFiles().size() > 0;
 
                     if (!accepted) {
-                        LOG.debug(">>>> Update postcondition(s) failed for {}: the DepositSubmission has no files" +
+                        LOG.debug(">>>> Update postcondition(s) failed for {}: the DepositSubmission has no files " +
                                         "attached! (Hint: check the incoming links to the Submission)",
                                 s.getId());
                     }

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
@@ -121,12 +121,21 @@ public class SubmissionProcessor implements Consumer<Submission> {
                     }
                     return accepted;
                 },
-                (s) -> {
+                (s, ds) -> {
                     boolean accepted = s.getAggregatedDepositStatus() == IN_PROGRESS;
                     if (!accepted) {
                         LOG.debug(">>>> Update postcondition(s) failed for {}: expected status '{}' but actual status is '{}'",
                                 s.getId(), IN_PROGRESS, s.getAggregatedDepositStatus());
                     }
+
+                    accepted &= ds.getFiles().size() > 0;
+
+                    if (!accepted) {
+                        LOG.debug(">>>> Update postcondition(s) failed for {}: the DepositSubmission has no files" +
+                                        "attached! (Hint: check the incoming links to the Submission)",
+                                s.getId());
+                    }
+
                     return accepted;
                 },
                 (s) -> {

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessor.java
@@ -122,21 +122,20 @@ public class SubmissionProcessor implements Consumer<Submission> {
                     return accepted;
                 },
                 (s, ds) -> {
-                    boolean accepted = s.getAggregatedDepositStatus() == IN_PROGRESS;
-                    if (!accepted) {
+                    if (s.getAggregatedDepositStatus() != IN_PROGRESS) {
                         LOG.debug(">>>> Update postcondition(s) failed for {}: expected status '{}' but actual status is '{}'",
                                 s.getId(), IN_PROGRESS, s.getAggregatedDepositStatus());
+                        return false;
                     }
 
-                    accepted &= ds.getFiles().size() > 0;
-
-                    if (!accepted) {
+                    if (ds.getFiles().size() < 1) {
                         LOG.debug(">>>> Update postcondition(s) failed for {}: the DepositSubmission has no files " +
                                         "attached! (Hint: check the incoming links to the Submission)",
                                 s.getId());
+                        return false;
                     }
 
-                    return accepted;
+                    return true;
                 },
                 (s) -> {
                     DepositSubmission ds = null;

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/AbstractSubmissionIT.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/AbstractSubmissionIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.service;
+
+import org.dataconservancy.nihms.builder.fs.PassJsonFedoraAdapter;
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.model.PassEntity;
+import org.dataconservancy.pass.model.Repository;
+import org.dataconservancy.pass.model.Submission;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.HashMap;
+
+import static org.dataconservancy.pass.deposit.messaging.service.SubmissionTestUtil.getDepositUris;
+import static org.dataconservancy.pass.model.Submission.AggregatedDepositStatus.NOT_STARTED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = { "spring.jms.listener.auto-startup=false" })
+public abstract class AbstractSubmissionIT {
+
+    protected static final String EXPECTED_REPO_NAME = "JScholarship";
+
+    protected Submission submission;
+
+    @Autowired
+    @Qualifier("submissionProcessor")
+    protected SubmissionProcessor underTest;
+
+    @Autowired
+    protected PassClient passClient;
+
+    /**
+     * Populates Fedora with a Submission, as if it was submitted interactively by a user of the PASS UI.
+     *
+     * @throws Exception
+     */
+    @Before
+    public void createSubmission() throws Exception {
+        PassJsonFedoraAdapter passAdapter = new PassJsonFedoraAdapter();
+
+        // Upload sample data to Fedora repository to get its Submission URI.
+        InputStream is = getSubmissionResources();
+
+        HashMap<URI, PassEntity> uriMap = new HashMap<>();
+        URI submissionUri = passAdapter.jsonToFcrepo(is, uriMap);
+        is.close();
+
+        // Find the Submission entity that was uploaded
+        for (URI key : uriMap.keySet()) {
+            PassEntity entity = uriMap.get(key);
+            if (entity.getId() == submissionUri) {
+                submission = (Submission)entity;
+                break;
+            }
+        }
+
+        assertNotNull("Missing expected Submission; it was not added to the repository.", submission);
+
+        // verify state of the initial Submission
+        assertEquals(Submission.Source.PASS, submission.getSource());
+        assertEquals(Boolean.TRUE, submission.getSubmitted());
+        assertEquals(NOT_STARTED, submission.getAggregatedDepositStatus());
+
+        // no Deposits pointing to the Submission
+        assertTrue("Unexpected incoming links to " + submissionUri,
+                getDepositUris(submission, passClient).isEmpty());
+
+        // JScholarship repository ought to exist
+        assertNotNull(submission.getRepositories());
+        assertTrue(submission.getRepositories().stream()
+                .map(uri -> (Repository)uriMap.get(uri))
+                .anyMatch(repo -> repo.getName().equals(EXPECTED_REPO_NAME)));
+
+    }
+
+    protected abstract InputStream getSubmissionResources();
+
+}

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/EmptySubmissionIT.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/EmptySubmissionIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.service;
+
+import afu.org.checkerframework.checker.igj.qual.I;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class EmptySubmissionIT extends AbstractSubmissionIT {
+
+    private static final String SUBMISSION_RESOURCES = "SubmissionProcessorIT-no-files.json";
+
+    @Override
+    protected InputStream getSubmissionResources() {
+        return SubmissionTestUtil.getSubmissionResources(SUBMISSION_RESOURCES);
+    }
+
+    @Test
+    @Ignore("TODO: Implement test when failure handling is properly implemented by SubmissionProcessor.")
+    public void submissionWithNoFiles() throws Exception {
+
+        // This submission should fail off the bat because there's no files in the submission.
+        underTest.accept(submission);
+
+        // We should observe a Submission with a status of FAILURE, no Deposits created, nor any RepositoryCopies
+        // created.
+
+        // The problem is that the failure handling for Submissions is inadequate at this point, and so Submissions
+        // are not yet marked as FAILED when this happens.  This will happen in a future PR.
+
+        // TODO: Implement test
+    }
+}

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionTestUtil.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionTestUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.service;
+
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Submission;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class SubmissionTestUtil {
+    public static Collection<URI> getDepositUris(Submission submission, PassClient passClient) {
+        Map<String, Collection<URI>> incoming = passClient.getIncoming(submission.getId());
+        return incoming.get("submission").stream().filter(uri -> {
+            try {
+                passClient.readResource(uri, Deposit.class);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }).collect(toSet());
+    }
+
+    public static InputStream getSubmissionResources(String resource) {
+        InputStream is = EmptySubmissionIT.class.getResourceAsStream(resource);
+        assertNotNull("Unable to resolve classpath resource " + resource, is);
+        return is;
+    }
+}

--- a/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessorIT-no-files.json
+++ b/deposit-messaging/src/test/resources/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessorIT-no-files.json
@@ -1,0 +1,129 @@
+[
+  {
+    "metadata" : "[{\"id\":\"JScholarship\",\"data\":{\"under-embargo\":\"true\",\"Embargo-end-date\":\"09/25/19\",\"embargo\":\"NON-EXCLUSIVE LICENSE FOR USE OF MATERIALS This non-exclusive license defines the terms for the deposit of Materials in all formats into the digital repository of materials collected, preserved and made available through the Johns Hopkins Digital Repository, JScholarship. The Contributor hereby grants to Johns Hopkins a royalty free, non-exclusive worldwide license to use, re-use, display, distribute, transmit, publish, re-publish or copy the Materials, either digitally or in print, or in any other medium, now or hereafter known, for the purpose of including the Materials hereby licensed in the collection of materials in the Johns Hopkins Digital Repository for educational use worldwide. In some cases, access to content may be restricted according to provisions established in negotiation with the copyright holder. This license shall not authorize the commercial use of the Materials by Johns Hopkins or any other person or organization, but such Materials shall be restricted to non-profit educational use. Persons may apply for commercial use by contacting the copyright holder. Copyright and any other intellectual property right in or to the Materials shall not be transferred by this agreement and shall remain with the Contributor, or the Copyright holder if different from the Contributor. Other than this limited license, the Contributor or Copyright holder retains all rights, title, copyright and other interest in the images licensed. If the submission contains material for which the Contributor does not hold copyright, the Contributor represents that s/he has obtained the permission of the Copyright owner to grant Johns Hopkins the rights required by this license, and that such third-party owned material is clearly identified and acknowledged within the text or content of the submission. If the submission is based upon work that has been sponsored or supported by an agency or organization other than Johns Hopkins, the Contributor represents that s/he has fulfilled any right of review or other obligations required by such contract or agreement. Johns Hopkins will not make any alteration, other than as allowed by this license, to your submission. This agreement embodies the entire agreement of the parties. No modification of this agreement shall be of any effect unless it is made in writing and signed by all of the parties to the agreement.\",\"agreement-to-embargo\":\"true\"}},{\"id\":\"common\",\"data\":{\"title\":\"Specific protein supplementation using soya, casein or whey differentially affects regional gut growth and luminal growth factor bioactivity in rats; implications for the treatment of gut injury and stimulating repair\",\"journal-title\":\"Food Funct.\",\"journal-title-short\":\"Food Funct.\",\"volume\":\"9\",\"issue\":\"1\",\"abstract\":\"Differential enhancement of luminal growth factor bioactivity and targeted regional gut growth occurs dependent on dietary protein supplement.\",\"subjects\":\"Food Science,General Medicine\",\"URL\":\"http://dx.doi.org/10.1039/c7fo01251a\",\"authors\":[{\"author\":\"Tania Marchbank\",\"orcid\":\"http://orcid.org/0000-0003-2076-9098\"},{\"author\":\"Nikki Mandir\"},{\"author\":\"Denis Calnan\"},{\"author\":\"Robert A. Goodlad\"},{\"author\":\"Theo Podas\"},{\"author\":\"Raymond J. Playford\",\"orcid\":\"http://orcid.org/0000-0003-1235-8504\"}]}},{\"id\":\"nih\",\"data\":{\"journal-NLMTA-ID\":\"TD452689\",\"ISSN\":\"2042-6496,2042-650X\"}}]",
+    "source" : "pass",
+    "submitted" : true,
+    "submittedDate" : "2017-06-02T00:00:00.000Z",
+    "aggregatedDepositStatus" : "not-started",
+    "publication" : "fake:publication1",
+    "repositories" : [ "fake:repository1" ],
+    "user" : "fake:user1",
+    "grants" : [ "fake:grant1" ],
+    "@id" : "fake:submission1",
+    "@type" : "Submission"
+  },
+  {
+    "title" : "This is the first submission",
+    "abstract" : "This is a great paper!",
+    "doi" : "abcdef",
+    "pmid" : "fedcba",
+    "journal" : "fake:journal1",
+    "volume" : "123",
+    "issue" : "May 2015",
+    "@id" : "fake:publication1",
+    "@type" : "Publication"
+  },
+  {
+    "name" : "AAPS PharmSci",
+    "issns" : [ "issn123", "issn456" ],
+    "nlmta" : "AAPS PharmSci",
+    "pmcParticipation" : "A",
+    "publisher" : "",
+    "@id" : "fake:journal1",
+    "@type" : "Journal"
+  },
+  {
+    "name" : "JScholarship",
+    "description" : "JHU Repository",
+    "url" : "http://example.com",
+    "formSchema" : "{}",
+    "@id" : "fake:repository1",
+    "@type" : "Repository"
+  },
+  {
+    "awardNumber" : "R01EY026617",
+    "awardStatus" : "active",
+    "localKey" : "112233",
+    "projectName" : "Optimal magnification and oculomotor strategies in low vision patients",
+    "awardDate" : "2017-06-01T00:00:00.000Z",
+    "startDate" : "2017-05-01T00:00:00.000Z",
+    "endDate" : "2018-06-01T00:00:00.000Z",
+    "primaryFunder" : "fake:funder1",
+    "directFunder" : "fake:funder2",
+    "pi" : "fake:user2",
+    "coPis" : [ "fake:user3" ],
+    "@id" : "fake:grant1",
+    "@type" : "Grant"
+  },
+  {
+    "name" : "National Eye Institute",
+    "url" : "http://example.com/eyeguys",
+    "localKey" : "aabbcc",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder1",
+    "@type" : "Funder"
+  },
+  {
+    "title" : "Be Nice to People With Eyes",
+    "description" : "We only have eyes for you.",
+    "policyUrl" : "http://theeyeshaveit.com/policy",
+    "repositories" : [ "fake:repository1" ],
+    "institution" : "fake:institution1",
+    "funder" : "fake:funder1",
+    "@id" : "fake:policy1",
+    "@type" : "Policy"
+  },
+  {
+    "name" : "International Eye Institute",
+    "url" : "http://example.com/othereyeguys",
+    "localKey" : "ddeeff",
+    "policy" : "fake:policy1",
+    "@id" : "fake:funder2",
+    "@type" : "Funder"
+  },
+  {
+    "username" : "bobsmith",
+    "firstName" : "Robert",
+    "middleName" : "Cure",
+    "lastName" : "Smith",
+    "displayName" : "Bob Smith",
+    "email" : "bobsmith@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "bs1",
+    "localKey" : "key123",
+    "orcidId" : "orcid123",
+    "roles" : [ "submitter", "admin" ],
+    "@id" : "fake:user1",
+    "@type" : "User"
+  },
+  {
+    "username" : "suzyv",
+    "firstName" : "Suzanne",
+    "middleName" : "X",
+    "lastName" : "Vega",
+    "displayName" : "Suzanne Vega",
+    "email" : "suzannev@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "sxv3",
+    "localKey" : "keyabc",
+    "orcidId" : "orc456",
+    "roles" : [ "submitter" ],
+    "@id" : "fake:user2",
+    "@type" : "User"
+  },
+  {
+    "username" : "johndoe",
+    "firstName" : "John",
+    "middleName" : "Nobody",
+    "lastName" : "Doe",
+    "displayName" : "John Doe",
+    "email" : "jd@jhu.edu",
+    "affiliation" : "Johns Hopkins",
+    "institutionalId" : "jd123",
+    "localKey" : "keyabc123",
+    "orcidId" : "orc789",
+    "roles" : [ "admin" ],
+    "@id" : "fake:user3",
+    "@type" : "User"
+  }
+]


### PR DESCRIPTION
When a `Submission` with no `Files` is processed by Deposit Services, some ugly stacktraces result.  This situation is not handled gracefully.

This PR is an interim solution to this problem.  The ultimate solution requires a holistic approach to `Submission` and `Deposit` failure handling, which is a PR that is in the works.

This PR checks the incoming `Submission` for files and treats it as a failure condition: if there are no files, a reasonable message and stack trace is emitted to the console, and processing stops.

**The `Submission` is left in an `IN_PROGRESS` state!**  This PR does not mark the `Submission` as failed, though that is likely what will happen in the future "failure-handling" PR.  

The reason is two-fold: (1) it requires a holistic approach as mentioned above, (2) this condition seems to be transient.  It is triggered by inconsistent behavior of Ember (though this is not confirmed).  If we mark the `Submission` as failed, there would be no subsequent attempts to process the `Submission`.  Because the Ember behavior is inconsistent, sometimes the files show up later, and the `Submission` can be processed.  So right now, this condition is treated as a transient failure, hoping that Ember recovers in time to process the Submission.

For this reason, test coverage is light.  Improved tests will be forthcoming in the "failure-handling" PR.