### PR TITLE
 Refactoring - moved manifest label code from ModelBuilder to NihmsMe…

### DIFF
--- a/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
+++ b/fedora-builder/src/main/java/org/dataconservancy/nihms/builder/fs/ModelBuilder.java
@@ -366,7 +366,7 @@ abstract class ModelBuilder {
                     depositFile.setLocation(file.getUri().toString());
                     // TODO - The client model currently only has "manuscript" and "supplemental" roles.
                     depositFile.setType(DepositFileType.valueOf(file.getFileRole().name().toLowerCase()));
-                    depositFile.setLabel(labelMaker.label(depositFile.getType(), file.getDescription()));
+                    depositFile.setLabel(file.getDescription());
                     files.add(depositFile);
                 }
             }

--- a/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/fedora-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -94,11 +94,6 @@ public class FilesystemModelBuilderTest {
         DepositMetadata.Manuscript manuscriptMetadata = submission.getMetadata().getManuscriptMetadata();
         assertEquals("http://dx.doi.org/10.1039/c7fo01251a", manuscriptMetadata.getManuscriptUrl().toString());
 
-        //test that the DepositFileLabelMaker is being called to supply the file labels
-        String label = submission.getManifest().getFiles().get(0).getLabel();//the image file - label required
-        assertEquals("A logo to test supplemental type", label);
-        label = submission.getManifest().getFiles().get(1).getLabel();//the manuscript file - empty label
-        assertEquals("", label);
     }
 
     @Test

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
@@ -16,6 +16,7 @@
 
 package org.dataconservancy.nihms.assembler.nihmsnative;
 import org.dataconservancy.nihms.model.DepositFile;
+import org.dataconservancy.nihms.model.DepositFileType;
 import org.dataconservancy.nihms.model.DepositManifest;
 
 import java.io.ByteArrayInputStream;
@@ -23,6 +24,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This class is a serializer for NihmsManifest which produces output conforming with the
@@ -42,19 +48,22 @@ public class NihmsManifestSerializer implements StreamingSerializer{
 
     private DepositManifest manifest;
 
-    public NihmsManifestSerializer(DepositManifest manifest){
+    public NihmsManifestSerializer(DepositManifest manifest) {
         this.manifest = manifest;
     }
+
 
     public InputStream serialize(){
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         PrintWriter writer = new PrintWriter(os);
 
+        DepositFileLabelMaker labelMaker = new DepositFileLabelMaker();
         for (DepositFile file : manifest.getFiles() ){
             writer.write(file.getType().toString());
             writer.append("\t");
-            if(file.getLabel() != null) {
-                writer.write(file.getLabel());
+            String label = labelMaker.getTypeUniqueLabel(file.getType(), file.getLabel());
+            if (label != null) {
+                writer.write(label);
             }
             writer.append("\t");
             String name = NihmsZippedPackageStream.getNonCollidingFilename(file.getName(), file.getType());
@@ -70,6 +79,99 @@ public class NihmsManifestSerializer implements StreamingSerializer{
             return is;
         } catch (IOException ioe) {
             throw new RuntimeException("Could not create Input Stream, or close Output Stream", ioe);
+        }
+    }
+
+    /**
+     * A utility inner class for generating unique labels for manifest entries for {@code DepositFile}s.
+     *
+     * From page 1 of the NIHMS Bulk Submission Specification for Funding Agencies, July 2017
+     *
+     *  "{label} is a label to differentiate between files of one {file_type} in the system.
+     *   This field is required for figure, table, and supplement file types.
+     *  {label} is used to identify files sent,such as 2a, 2b, and so on.
+     *  In the case of supplemental files, the string supplied here will be used as text for a hyperlink in the PMC manuscript.
+
+     * If the label is not required, we make sure that any supplied label has not been used for a file of that type yet.
+     *
+     * @author jrm@jhu.edu
+     */
+
+    class DepositFileLabelMaker {
+        /**
+         * The label types required by the NIHMS Bulk Submission Specifications for Funding Agencies, July 2017
+         */
+        private final DepositFileType[] requiredLabelTypes = {
+                DepositFileType.figure,
+                DepositFileType.table,
+                DepositFileType.supplemental
+        };
+
+        private final Set<DepositFileType> requiredTypes = new HashSet<>(Arrays.asList(requiredLabelTypes));
+
+        private Map<DepositFileType, Set<String>> usedFileLabels = createLabelMap();
+
+        /**
+         * An initialization method to populate a Map which tracks used labels for any file type
+         *
+         * @return the label Map
+         */
+        private Map<DepositFileType, Set<String>> createLabelMap() {
+            Map<DepositFileType, Set<String>> labelMap = new HashMap<>();
+            for (DepositFileType fileType : Arrays.asList(DepositFileType.values())) {
+                labelMap.put(fileType, new HashSet<>());
+            }
+            return labelMap;
+        }
+
+        /**
+         * Return a unique label for a {@code DepositFile}. If the label is not required, we make sure that any
+         * supplied label has not been used for a file of that type yet.
+         *
+         * @param type the {@code DepositFileType} of the {@code DepositFile} requesting a label
+         * @param description the user-supplied description of the file
+         * @return the type-unique file label if supplied or required
+         */
+        String getTypeUniqueLabel(DepositFileType type, String description) {
+
+            String label;
+            boolean missing = false;
+
+            //first see if we have any content in the supplied description/label
+            if (description == null || description.replaceAll("\\s", "").length() == 0) {
+                description = "";
+            }
+
+            //tabs are used to separate fields in the manifest, so we can't have them in our string
+            label = description.replaceAll("\t", " ").trim();
+
+            //if the label is content-less, we can return it if not required, but must construct one if required
+            if (label.length() == 0) {
+                if (requiredTypes.contains(type)) {
+                    label = type.toString();//we require a label for these files, let's build one
+                    missing = true;
+                } else {
+                    return "";
+                }
+            }
+
+            //we have a string as a candidate. if it is required and the initial label was empty,
+            //we start with <type>-1 as a first try
+            //otherwise, just use the supplied label.
+            String firstTry = missing ? label + "-1" : label;
+            if (!usedFileLabels.get(type).contains(firstTry)) {
+                usedFileLabels.get(type).add(firstTry);
+                return firstTry;
+            }
+
+            //uh-oh, our first try is already used, let's generate a free one
+            int i = missing ? 2 : 1;//optimization :-)
+            while (usedFileLabels.get(type).contains(label + "-" + Integer.toString(i))) {
+                i++;
+            }
+            label = label + "-" + Integer.toString(i);
+            usedFileLabels.get(type).add(label);
+            return label;
         }
     }
 

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializerTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializerTest.java
@@ -86,4 +86,60 @@ public class NihmsManifestSerializerTest {
         assertEquals(expected, actual);
 
     }
+
+    @Test
+    public void labelMakerTest() {
+
+        NihmsManifestSerializer underTest = new NihmsManifestSerializer(null);
+        NihmsManifestSerializer.DepositFileLabelMaker labelMaker = underTest.new DepositFileLabelMaker();
+
+        String label = labelMaker.getTypeUniqueLabel(DepositFileType.figure, null);
+        assertEquals("figure-1", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.figure, null);
+        assertEquals("figure-2", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.figure, "   ");
+        assertEquals("figure-3", label);
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.supplemental, "figure-1");
+        assertEquals("figure-1", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.supplemental, null);
+        assertEquals("supplemental-1", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.supplemental, "");
+        assertEquals("supplemental-2", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.supplemental, null);
+        assertEquals("supplemental-3", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.manuscript, "Moo Cows in the Pasture");
+        assertEquals("Moo Cows in the Pasture", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.figure, "Spotted Cows");
+        assertEquals("Spotted Cows", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.figure, "Spotted Cows");
+        assertEquals("Spotted Cows-1", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.figure, "Spotted Cows     ");
+        assertEquals("Spotted Cows-2", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.figure, "Spotted Cows-2");
+        assertEquals("Spotted Cows-2-1", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.table, "table");
+        assertEquals("table", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.table, "table-1");
+        assertEquals("table-1", label );
+
+        label = labelMaker.getTypeUniqueLabel(DepositFileType.table, "");
+        assertEquals("table-2", label );
+
+
+    }
+    
 }
+    


### PR DESCRIPTION
…tadataSerializer

 Updated tests to enforce correct compliance for labels in the manifest:
    - figure, table and supplemental files require labels
    - all labels must be type-unique