### PR TITLE
Insures the file transfer mode is set properly on the client and server.

### DIFF
--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
@@ -216,8 +216,8 @@ public class FtpTransportSession implements TransportSession {
             }
             setPasv(ftpClient, true);
             setDataType(ftpClient, binary.name());
-            performSilently(ftpClient, ftpClient -> ftpClient.storeFile(finalFileName, content));
-            success.set(true);
+            boolean result = ftpClient.storeFile(finalFileName, content);
+            success.set(result);
             ftpReplyCode.set(ftpClient.getReplyCode());
             ftpReplyString.set(ftpClient.getReplyString());
         } catch (Exception e) {

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
@@ -201,15 +201,29 @@ public class FtpUtil {
             throw new RuntimeException("Unknown FTP file type '" + dataType + "'");
         }
 
+        boolean success = false;
+
         switch (type) {
             case ascii:
-                performSilently(ftpClient, () -> ftpClient.type(FTP.ASCII_FILE_TYPE));
+                try {
+                    success = ftpClient.setFileType(FTP.ASCII_FILE_TYPE);
+                } catch (IOException e) {
+                    throw new RuntimeException("Error setting FTP file type to " + type, e);
+                }
                 break;
             case binary:
-                performSilently(ftpClient, () -> ftpClient.type(FTP.BINARY_FILE_TYPE));
+                try {
+                    success = ftpClient.setFileType(FTP.BINARY_FILE_TYPE);
+                } catch (IOException e) {
+                    throw new RuntimeException("Error setting FTP file type to " + type, e);
+                }
                 break;
             default:
                 throw new RuntimeException("Unsupported FTP file type '" + dataType + "'");
+        }
+
+        if (!success) {
+            throw new RuntimeException("Unable to set FTP file type to " + type);
         }
     }
 

--- a/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
+++ b/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
@@ -20,7 +20,9 @@ import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPReply;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentMatcher;
 
 import java.io.IOException;
@@ -49,6 +51,9 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class FtpUtilTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     private FTPClient ftpClient;
 
@@ -97,13 +102,11 @@ public class FtpUtilTest {
      */
     @Test
     public void setDataTypeBinarySuccess() throws IOException {
-        when(ftpClient.type(anyInt())).thenReturn(FTPReply.COMMAND_OK);
-        when(ftpClient.getReplyCode()).thenReturn(FTPReply.COMMAND_OK);
+        when(ftpClient.setFileType(FTP.BINARY_FILE_TYPE)).thenReturn(true);
 
         FtpUtil.setDataType(ftpClient, binary.name());
 
-        verify(ftpClient).type(eq(FTP.BINARY_FILE_TYPE));
-        verify(ftpClient).getReplyCode();
+        verify(ftpClient).setFileType(FTP.BINARY_FILE_TYPE);
     }
 
     /**
@@ -111,12 +114,16 @@ public class FtpUtilTest {
      *
      * @throws IOException
      */
-    @Test(expected = RuntimeException.class)
+    @Test
     public void setDataTypeBinaryFail() throws IOException {
-        when(ftpClient.type(anyInt())).thenReturn(FTPReply.REQUEST_DENIED);
-        when(ftpClient.getReplyCode()).thenReturn(FTPReply.REQUEST_DENIED);
+        when(ftpClient.setFileType(anyInt())).thenReturn(false);
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Unable to set FTP file type to");
 
         FtpUtil.setDataType(ftpClient, binary.name());
+
+        verify(ftpClient).setFileType(anyInt());
     }
 
     /**
@@ -127,13 +134,11 @@ public class FtpUtilTest {
      */
     @Test
     public void setDataTypeAsciiSuccess() throws IOException {
-        when(ftpClient.type(anyInt())).thenReturn(FTPReply.COMMAND_OK);
-        when(ftpClient.getReplyCode()).thenReturn(FTPReply.COMMAND_OK);
+        when(ftpClient.setFileType(FTP.ASCII_FILE_TYPE)).thenReturn(true);
 
         FtpUtil.setDataType(ftpClient, ascii.name());
 
-        verify(ftpClient).type(eq(FTP.ASCII_FILE_TYPE));
-        verify(ftpClient).getReplyCode();
+        verify(ftpClient).setFileType(FTP.ASCII_FILE_TYPE);
     }
 
     /**


### PR DESCRIPTION
`ftpClient.type(...)` sets the type on the _server_ side, but **not** on the client side.  So if you set the type to binary using this method call, the client will transfer in ascii mode, while the server expects binary, and the upload is corrupted.

Use `ftpClient.fileType(...)` instead, which takes care of both the client and server.