### PR TITLE
Treat DepositSubmission model as if it were immutable

### DIFF
--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
@@ -60,13 +60,6 @@ public class NihmsAssembler extends AbstractAssembler {
         mb.compression(PackageStream.COMPRESSION.GZIP);
         mb.mimeType(APPLICATION_GZIP);
 
-        // Add manifest entry for metadata file
-        DepositFile metadataFile = new DepositFile();
-        metadataFile.setName(NihmsZippedPackageStream.METADATA_ENTRY_NAME);
-        metadataFile.setType(DepositFileType.bulksub_meta_xml);
-        metadataFile.setLabel("Metadata");
-        submission.getManifest().getFiles().add(metadataFile);
-
         NihmsZippedPackageStream stream = new NihmsZippedPackageStream(submission, custodialResources, mb, rbf);
         stream.setManifestSerializer(new NihmsManifestSerializer(submission.getManifest()));
         stream.setMetadataSerializer(new NihmsMetadataSerializer(submission.getMetadata()));

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
@@ -70,6 +70,12 @@ public class NihmsManifestSerializer implements StreamingSerializer{
             writer.write(name);
             writer.append("\n");
         }
+
+        // FIXME: Hack to include the bulk_meta.xml in the manifest if it wasn't included
+        if (manifest.getFiles().stream().noneMatch(df -> df.getType() == DepositFileType.bulksub_meta_xml)) {
+            includeBulkMetadataInManifest(writer, labelMaker);
+        }
+
         writer.close();
 
         byte[] bytes = os.toByteArray();
@@ -80,6 +86,14 @@ public class NihmsManifestSerializer implements StreamingSerializer{
         } catch (IOException ioe) {
             throw new RuntimeException("Could not create Input Stream, or close Output Stream", ioe);
         }
+    }
+
+    protected static void includeBulkMetadataInManifest(PrintWriter writer, DepositFileLabelMaker labelMaker) {
+        writer.write(DepositFileType.bulksub_meta_xml.name());
+        writer.append("\t");
+        writer.write(labelMaker.getTypeUniqueLabel(DepositFileType.bulksub_meta_xml, "Submission Metadata"));
+        writer.append("\t");
+        writer.write(NihmsZippedPackageStream.METADATA_ENTRY_NAME);
     }
 
     /**


### PR DESCRIPTION
Fixed bug where one Assembler's modification of the `DepositSubmission` cause another Assembler to fail.

The `DepositSubmission` model is now shared between all Assemblers (see `SubmissionProcessor`).

`NihmsAssembler` modifies the `DepositManifest` by adding a `DepositFile` for the bulk submission metadata.  The bulk submission metadata doesn't actually exist anywhere, it is generated by the `NihmsMetadataSerializer`, and as such, the `DepositFile` representing the metadata has no location URI.

By the time `NihmsAssembler` modifies the `DepositManifest`, the `DepositManifest` has already been "validated", which insures that each `DepositFile` in the manifest has a valid location URI.  Because the validation has already occurred by the time the `DepositFile` is added, assembly of the NIHMs package proceeds without error.

If another Assembler is executed over the same `DepositSubmission`, it will re-validate the `DepositManifest`.  First, the `DepositManifest` contains a `DepositFile` (the bulk submission metadata added by `NihmsAssembler`) that it shouldn't.  Second, the `DepositFile` has no location URI, so when the second Assembler attempts to resolve the bytes associated with the `DepositFile`, an NPE is thrown when resolving the content.

This hack simply updates the `NimsManifestSerializer` to include a line for the NIH bulk submission metadata.