### PR TITLE
Name NIH packages with reasonable filenames.

### DIFF
--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
@@ -191,32 +191,13 @@ public class FtpTransportSession implements TransportSession {
             directory = destinationResource.substring(0, destinationResource.lastIndexOf(PATH_SEP));
         }
 
-        //temporary adjustment to allow multiple submissions in demo to not overwrite files on ftp server
-        //NOTE the original variable fileName was used below in a lambda expression - we had to change this to
-        //finalFileName to satisfy the finality requirement. when this adjustment is removed, the finalFileName variable
-        //in the try block (performSilently ... )below can be reverted to fileName
-        String base;
-        String extension;
-        if (fileName.contains(".")) {
-            int i = fileName.indexOf("."); //there may be more than one (.tar.gz)
-            base = fileName.substring(0, i);
-            extension = fileName.substring(i); //save the "."
-        } else {
-            base = fileName;
-            extension = "";
-        }
-        String pseudoTimeStamp = String.format("%04d", System.currentTimeMillis() % 10000);
-        fileName = base + pseudoTimeStamp + extension;
-        String finalFileName = fileName;
-        //end of adjustment
-
         try {
             if (directory != null) {
                 FtpUtil.setWorkingDirectory(ftpClient, directory);
             }
             setPasv(ftpClient, true);
             setDataType(ftpClient, binary.name());
-            boolean result = ftpClient.storeFile(finalFileName, content);
+            boolean result = ftpClient.storeFile(fileName, content);
             success.set(result);
             ftpReplyCode.set(ftpClient.getReplyCode());
             ftpReplyString.set(ftpClient.getReplyString());

--- a/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
+++ b/shared-assembler/src/main/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssembler.java
@@ -281,6 +281,11 @@ public abstract class AbstractAssembler implements Assembler {
             return true;
         }
 
+        // Allow period (0x2e), dash (0x2d), underscore (0x5f)
+        if (i == 0x002e || i == 0x002d || i == 0x005f) {
+            return true;
+        }
+
         // otherwise it's an illegal character inside of the latin-1 code block
         return false;
     }

--- a/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssemblerTest.java
+++ b/shared-assembler/src/test/java/org/dataconservancy/pass/deposit/assembler/shared/AbstractAssemblerTest.java
@@ -29,9 +29,13 @@ public class AbstractAssemblerTest {
     @Test
     public void testSanitize() {
         assertEquals("foo", AbstractAssembler.sanitizeFilename("foo"));
-        assertEquals("foo", AbstractAssembler.sanitizeFilename("f.o.o"));
+        assertEquals("f.o.o", AbstractAssembler.sanitizeFilename("f.o.o"));
         assertEquals("foo", AbstractAssembler.sanitizeFilename("foo" + '\u00F6'));
-        assertEquals("foo", AbstractAssembler.sanitizeFilename("../foo"));
+        assertEquals("..foo", AbstractAssembler.sanitizeFilename("../foo"));
         assertEquals("foo", AbstractAssembler.sanitizeFilename("f o o"));
+        assertEquals("foo-", AbstractAssembler.sanitizeFilename("foo-"));
+        assertEquals("fo-o", AbstractAssembler.sanitizeFilename("fo-o"));
+        assertEquals("f_oo", AbstractAssembler.sanitizeFilename("f_oo"));
+        assertEquals("_foo_", AbstractAssembler.sanitizeFilename("_foo_"));
     }
 }


### PR DESCRIPTION
- Include unique strings in the filename so the filename hack in FtpTransportSession is no longer needed
- Allow hyphens, periods, and underscores in filenames
- Use the packaging spec and current date and time in the filename.