### PR TITLE
Include Git revision information in the startup console for Deposit Services

### DIFF
--- a/builder-api/pom.xml
+++ b/builder-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>builder-api</artifactId>

--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>deposit-messaging</artifactId>

--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -97,6 +97,26 @@
         <plugins>
 
             <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <abbrevLength>8</abbrevLength>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>gitproperties</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <!--<configuration>-->

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
@@ -26,7 +26,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 
+import java.io.IOException;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.Properties;
 
 
 /**
@@ -40,14 +43,45 @@ public class DepositApp {
 
     private static final Logger LOG = LoggerFactory.getLogger(DepositApp.class);
 
+    private static final String GIT_BUILD_VERSION_KEY = "git.build.version";
+
+    private static final String GIT_COMMIT_HASH_KEY = "git.commit.id.abbrev";
+
+    private static final String GIT_COMMIT_TIME_KEY = "git.commit.time";
+
+    private static final String GIT_DIRTY_FLAG = "git.dirty";
+
+    private static final String GIT_BRANCH = "git.branch";
+
     private String fcrepoUser;
 
     private String fcrepoPass;
 
     private String fcrepoBaseUrl;
 
+    private static final String GIT_PROPERTIES_RESOURCE_PATH = "/git.properties";
+
     public static void main(String[] args) {
-        LOG.info(">>>> Starting DepositService");
+
+        URL gitPropertiesResource = DepositApp.class.getResource(GIT_PROPERTIES_RESOURCE_PATH);
+        if (gitPropertiesResource == null) {
+            LOG.info(">>>> Starting DepositServices (no Git commit information available)");
+        } else {
+            Properties gitProperties = new Properties();
+            try {
+                gitProperties.load(gitPropertiesResource.openStream());
+                boolean isDirty = Boolean.valueOf(gitProperties.getProperty(GIT_DIRTY_FLAG));
+
+                LOG.info(">>>> Starting DepositServices (version: {} branch: {} commit: {} commit date: {})",
+                        gitProperties.get(GIT_BUILD_VERSION_KEY), gitProperties.get(GIT_BRANCH), gitProperties.get(GIT_COMMIT_HASH_KEY), gitProperties.getProperty(GIT_COMMIT_TIME_KEY));
+
+                if (isDirty) {
+                    LOG.warn(">>>> ** Deposit Services was compiled from a Git repository with uncommitted changes! **");
+                }
+            } catch (IOException e) {
+                LOG.warn(">>>> Starting DepositService (" + GIT_PROPERTIES_RESOURCE_PATH + " could not be parsed: " + e.getMessage() + ")");
+            }
+        }
 
         if (args.length < 1 || args[0] == null) {
             throw new IllegalArgumentException("Requires at least one argument!");

--- a/deposit-model/pom.xml
+++ b/deposit-model/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>deposit-model</artifactId>

--- a/dspace-mets-assembler/pom.xml
+++ b/dspace-mets-assembler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dspace-mets-assembler</artifactId>

--- a/fedora-builder/pom.xml
+++ b/fedora-builder/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>fedora-builder</artifactId>

--- a/nihms-assembler-api/pom.xml
+++ b/nihms-assembler-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>nihms-assembler-api</artifactId>

--- a/nihms-cli/pom.xml
+++ b/nihms-cli/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>nihms-cli</artifactId>

--- a/nihms-ftp-transport/pom.xml
+++ b/nihms-ftp-transport/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>nihms-ftp-transport</artifactId>

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>nihms-integration</artifactId>

--- a/nihms-native-assembler/pom.xml
+++ b/nihms-native-assembler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>nihms-native-assembler</artifactId>

--- a/nihms-submission-engine/pom.xml
+++ b/nihms-submission-engine/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>nihms-submission-engine</artifactId>

--- a/nihms-transport-api/pom.xml
+++ b/nihms-transport-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>nihms-transport-api</artifactId>

--- a/nihms-util/pom.xml
+++ b/nihms-util/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>nihms-util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.dataconservancy.nihms</groupId>
     <artifactId>nihms-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.0.6-2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>NIH Package and Submission Parent Project</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <maven.remote-resources.plugin.version>1.5</maven.remote-resources.plugin.version>
         <codehaus.build-helper.plugin.version>1.10</codehaus.build-helper.plugin.version>
         <fabric8.docker.maven.plugin.version>0.24.0</fabric8.docker.maven.plugin.version>
+        <git-commit-plugin.version>2.2.4</git-commit-plugin.version>
         <slf4j.version>1.7.25</slf4j.version>
         <logback-classic.version>1.2.3</logback-classic.version>
         <junit.version>4.12</junit.version>
@@ -116,6 +117,12 @@
         <pluginManagement>
 
             <plugins>
+
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>${git-commit-plugin.version}</version>
+                </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/shared-assembler/pom.xml
+++ b/shared-assembler/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>shared-assembler</artifactId>

--- a/sword2-transport/pom.xml
+++ b/sword2-transport/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.dataconservancy.nihms</groupId>
         <artifactId>nihms-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.0.6-2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>sword2-transport</artifactId>


### PR DESCRIPTION
- Uses a Maven plugin to generate a `git.properties` file which will be stored on the production runtime classpath.
- The `git.properties` is introspected at runtime to get version information.
- Maven POMs have their versions update to be congruent with the Docker image versioning, allowing testers and operations staff to see a sane version number when starting Deposit Services.
