### PR TITLE
Support the refresh of a Deposit DepositStatus

### DIFF
--- a/deposit-messaging/pom.xml
+++ b/deposit-messaging/pom.xml
@@ -341,6 +341,23 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <configuration>
+                    <resourceBundles>
+                        <resourceBundle>org.dataconservancy.nihms:shared-assembler:${project.parent.version}:test-jar:tests</resourceBundle>
+                    </resourceBundles>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
 
     </build>
@@ -520,6 +537,15 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dataconservancy.nihms</groupId>
+            <artifactId>shared-assembler</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/DepositApp.java
@@ -94,7 +94,7 @@ public class DepositApp {
                 app = new SpringApplication(DepositApp.class, ListenerRunner.class);
                 break;
             }
-            case "update": {
+            case "refresh": {
                 app = new SpringApplication(DepositApp.class, SubmittedUpdateRunner.class);
                 // TODO figure out elegant way to exclude JMS-related beans like SubmissionProcessor from being spun up
                 app.setDefaultProperties(new HashMap<String, Object>() { {

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/DepositConfig.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/config/DepositConfig.java
@@ -36,6 +36,7 @@ import org.dataconservancy.pass.deposit.messaging.model.Packager;
 import org.dataconservancy.pass.deposit.messaging.model.Registry;
 import org.dataconservancy.pass.deposit.messaging.policy.DirtyDepositPolicy;
 import org.dataconservancy.pass.deposit.messaging.service.DepositTask;
+import org.dataconservancy.pass.deposit.messaging.status.AbderaDepositStatusRefProcessor;
 import org.dataconservancy.pass.deposit.messaging.status.AtomFeedStatusMapper;
 import org.dataconservancy.pass.deposit.messaging.status.RepositoryCopyStatusMapper;
 import org.dataconservancy.pass.deposit.messaging.status.SwordDspaceDepositStatusMapper;
@@ -212,11 +213,13 @@ public class DepositConfig {
     @Bean
     public Map<String, Packager> packagers(DspaceMetsAssembler dspaceAssembler, Sword2Transport swordTransport,
                                            NihmsAssembler nihmsAssembler, FtpTransport ftpTransport,
-                                           Map<String, Map<String, String>> transportRegistries) {
+                                           Map<String, Map<String, String>> transportRegistries,
+                                           AbderaDepositStatusRefProcessor abderaDepositStatusRefProcessor) {
         Map<String, Packager> packagers = new HashMap<>();
         // TODO: transport registries looked up by hard-coded strings.  Need a more reliable way of discovering repositories, the packagers for those repositories, and their configuration
         packagers.put("JScholarship",
-                new Packager("JScholarship", dspaceAssembler, swordTransport, transportRegistries.get("js")));
+                new Packager("JScholarship", dspaceAssembler, swordTransport, transportRegistries.get("js"),
+                        abderaDepositStatusRefProcessor));
         packagers.put("PubMed Central",
                 new Packager("PubMed Central", nihmsAssembler, ftpTransport, transportRegistries.get("nihms")));
         return packagers;

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/model/Packager.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/model/Packager.java
@@ -17,6 +17,7 @@ package org.dataconservancy.pass.deposit.messaging.model;
 
 import org.dataconservancy.nihms.assembler.Assembler;
 import org.dataconservancy.nihms.transport.Transport;
+import org.dataconservancy.pass.deposit.messaging.service.DepositStatusRefProcessor;
 import org.dataconservancy.pass.deposit.messaging.service.DepositTask;
 import org.dataconservancy.pass.model.Repository;
 import org.dataconservancy.pass.model.Submission;
@@ -50,12 +51,20 @@ public class Packager {
 
     private Transport transport;
 
+    private DepositStatusRefProcessor depositStatusProcessor;
+
     private Map<String, String> configuration;
 
     public Packager(String name, Assembler assembler, Transport transport, Map<String, String> configuration) {
+        this(name, assembler, transport, configuration, null);
+    }
+
+    public Packager(String name, Assembler assembler, Transport transport, Map<String, String> configuration,
+                    DepositStatusRefProcessor depositStatusProcessor) {
         this.name = name;
         this.assembler = assembler;
         this.transport = transport;
+        this.depositStatusProcessor = depositStatusProcessor;
         this.configuration = configuration;
     }
 
@@ -79,6 +88,15 @@ public class Packager {
                         toHexString(identityHashCode(this)),
                         entry.getKey(), entry.getValue()))
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * The {@link DepositStatusRefProcessor}, may be {@code null}.
+     *
+     * @return the {@link DepositStatusRefProcessor}, may be {@code null}.
+     */
+    public DepositStatusRefProcessor getDepositStatusProcessor() {
+        return depositStatusProcessor;
     }
 
 }

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositStatusRefProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositStatusRefProcessor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.service;
+
+import org.dataconservancy.pass.model.Deposit;
+
+import java.net.URI;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public interface DepositStatusRefProcessor {
+
+    Deposit.DepositStatus process(URI depositStatusRef);
+
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
@@ -80,6 +80,7 @@ public class DepositTask implements Runnable {
     private Policy<Deposit.DepositStatus> terminalDepositStatusPolicy;
 
     private CriticalRepositoryInteraction critical;
+    private long swordSleepTimeMs = 10000;
 
     public DepositTask(DepositUtil.DepositWorkerContext dc, PassClient passClient,
                        DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser,
@@ -192,8 +193,8 @@ public class DepositTask implements Runnable {
             // TODO: abstract out a configurable timer.
             // Sleep here for a bit, let DSpace do its thing, and then we ought to be able to parse a deposit status
             try {
-                LOG.debug(">>>> Sleeping 10 seconds for SWORD deposit to complete ...");
-                Thread.sleep(10000);
+                LOG.debug(">>>> Sleeping {} ms for SWORD deposit to complete ...", swordSleepTimeMs);
+                Thread.sleep(swordSleepTimeMs);
             } catch (InterruptedException e) {
                 LOG.debug(">>>> DepositTask {}@{} interrupted!",
                         DepositTask.class.getSimpleName(), toHexString(identityHashCode(this)));

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
@@ -22,19 +22,18 @@ import org.dataconservancy.pass.client.PassClient;
 import org.dataconservancy.pass.deposit.messaging.DepositServiceRuntimeException;
 import org.dataconservancy.pass.deposit.messaging.model.Packager;
 import org.dataconservancy.pass.deposit.messaging.policy.Policy;
-import org.dataconservancy.pass.deposit.messaging.status.DepositStatusMapper;
-import org.dataconservancy.pass.deposit.messaging.status.DepositStatusParser;
-import org.dataconservancy.pass.deposit.messaging.status.SwordDspaceDepositStatus;
+import org.dataconservancy.pass.deposit.messaging.service.DepositUtil.DepositWorkerContext;
 import org.dataconservancy.pass.deposit.messaging.support.CriticalRepositoryInteraction;
 import org.dataconservancy.pass.deposit.messaging.support.CriticalRepositoryInteraction.CriticalResult;
 import org.dataconservancy.pass.deposit.transport.sword2.Sword2DepositReceiptResponse;
 import org.dataconservancy.pass.model.Deposit;
 import org.dataconservancy.pass.model.RepositoryCopy;
+import org.dataconservancy.pass.model.RepositoryCopy.CopyStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Map;
 
@@ -42,7 +41,6 @@ import static java.lang.Integer.toHexString;
 import static java.lang.String.format;
 import static java.lang.System.identityHashCode;
 import static org.dataconservancy.pass.model.Deposit.DepositStatus.ACCEPTED;
-import static org.dataconservancy.pass.model.Deposit.DepositStatus.REJECTED;
 import static org.dataconservancy.pass.model.Deposit.DepositStatus.SUBMITTED;
 
 /**
@@ -67,34 +65,28 @@ public class DepositTask implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(DepositTask.class);
 
-    private DepositUtil.DepositWorkerContext dc;
+    private DepositWorkerContext dc;
 
     private PassClient passClient;
 
-    private DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser;
-
-    private DepositStatusMapper<SwordDspaceDepositStatus> swordDepositStatusMapper;
-
     private Policy<Deposit.DepositStatus> intermediateDepositStatusPolicy;
 
-    private Policy<Deposit.DepositStatus> terminalDepositStatusPolicy;
+    private CriticalRepositoryInteraction cri;
 
-    private CriticalRepositoryInteraction critical;
+    private DepositTaskHelper depositHelper;
+
     private long swordSleepTimeMs = 10000;
 
-    public DepositTask(DepositUtil.DepositWorkerContext dc, PassClient passClient,
-                       DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser,
-                       DepositStatusMapper<SwordDspaceDepositStatus> swordDepositStatusMapper,
+    public DepositTask(DepositWorkerContext dc,
+                       PassClient passClient,
                        Policy<Deposit.DepositStatus> intermediateDepositStatusPolicy,
-                       Policy<Deposit.DepositStatus> terminalDepositStatusPolicy,
-                       CriticalRepositoryInteraction critical) {
+                       CriticalRepositoryInteraction cri,
+                       DepositTaskHelper depositHelper) {
         this.dc = dc;
         this.passClient = passClient;
-        this.atomStatusParser = atomStatusParser;
-        this.swordDepositStatusMapper = swordDepositStatusMapper;
         this.intermediateDepositStatusPolicy = intermediateDepositStatusPolicy;
-        this.terminalDepositStatusPolicy = terminalDepositStatusPolicy;
-        this.critical = critical;
+        this.cri = cri;
+        this.depositHelper = depositHelper;
     }
 
     @Override
@@ -102,7 +94,7 @@ public class DepositTask implements Runnable {
 
         LOG.debug(">>>> Running {}@{}", DepositTask.class.getSimpleName(), toHexString(identityHashCode(this)));
 
-        CriticalResult<TransportResponse, Deposit> result = critical.performCritical(dc.deposit().getId(), Deposit.class,
+        CriticalResult<TransportResponse, Deposit> result = cri.performCritical(dc.deposit().getId(), Deposit.class,
 
                 /*
                  * Only "intermediate" deposits can be processed by {@code DepositTask}
@@ -201,16 +193,18 @@ public class DepositTask implements Runnable {
                 Thread.interrupted();
             }
 
-            // deposit receipt -> SWORD Statement (ORE ReM/Atom XML) -> sword:state
-            Sword2DepositReceiptResponse swordResponse = (Sword2DepositReceiptResponse) transportResponse;
-            String itemUri = swordResponse.getReceipt().getEntry().getAlternateLink().getHref().toString();
             URI statementUri = null;
-            Deposit.DepositStatus status = null;
+            String itemUri = null;
             try {
+                Sword2DepositReceiptResponse swordResponse = (Sword2DepositReceiptResponse) transportResponse;
+
+                // deposit receipt -> SWORD Statement (ORE ReM/Atom XML) -> sword:state
+                if (swordResponse.getReceipt().getSplashPageLink() != null) {
+                    itemUri = swordResponse.getReceipt().getSplashPageLink().getHref();
+                }
+
+                // deposit receipt -> DSpace Item URL
                 statementUri = swordResponse.getReceipt().getAtomStatementLink().getIRI().toURI();
-                dc.deposit().setDepositStatusRef(statementUri.toString());
-                SwordDspaceDepositStatus swordStatus = atomStatusParser.parse(statementUri);
-                status = swordDepositStatusMapper.map(swordStatus);
             } catch (Exception e) {
                 String msg = format("Failed to update deposit status to %s for tuple [%s, %s, %s]; " +
                             "parsing the Atom statement %s for %s failed: %s",
@@ -219,98 +213,47 @@ public class DepositTask implements Runnable {
                 throw new DepositServiceRuntimeException(msg, e, dc.deposit());
             }
 
-            switch (status) {
-                case ACCEPTED: {
-                    LOG.info(">>>> Deposit {} was accepted.", dc.deposit().getId());
-                    dc.deposit().setDepositStatus(ACCEPTED);
-                    RepositoryCopy repoCopy = new RepositoryCopy();
-                    repoCopy.setCopyStatus(RepositoryCopy.CopyStatus.COMPLETE);
-                    repoCopy.setRepository(dc.repository().getId());
-                    repoCopy.setPublication(dc.submission().getPublication());
-                    repoCopy.setExternalIds(Collections.singletonList(itemUri));
-                    dc.repoCopy(repoCopy);
-                    break;
-                }
+            // TransportResponse was successfully parsed, set the status ref
+            dc.deposit().setDepositStatusRef(statementUri.toString());
 
-                case REJECTED: {
-                    LOG.info(">>>> Deposit {} was rejected.", dc.deposit().getId());
-                    dc.deposit().setDepositStatus(Deposit.DepositStatus.REJECTED);
-                    break;
-                }
-            }
-        }
+            // Create a RepositoryCopy, which will record the URL of the Item in DSpace
+            RepositoryCopy repoCopy = newRepositoryCopy(dc, itemUri, CopyStatus.IN_PROGRESS);
+            dc.repoCopy(repoCopy);
 
-        // TransportResponse was successfully parsed and logical success or failure of the Deposit was determined.
-        // Create the RepositoryCopy and update the Deposit
-
-
-        CriticalResult<RepositoryCopy, Deposit> finalResult = critical.performCritical(dc.deposit().getId(), Deposit.class,
-
-                (deposit) -> {
-                    if (deposit.getDepositStatus() != Deposit.DepositStatus.SUBMITTED) {
-                        LOG.debug("Precondition for updating {} was not satisfied.  Expected " +
-                                "Deposit.DepositStatus={}, but was {}",
-                                deposit.getId(), SUBMITTED, deposit.getDepositStatus());
-                        return false;
-                    }
-
-                    return true;
-                },
-
-                (deposit) -> {
-                    // As long as a Deposit is not FAILED, we are OK with the final result.
-                    //
-                    // A SWORD deposit may have taken longer than 10s (they are async, after all), so the Deposit
-                    // may be in the SUBMITTED state still.
-                    //
-                    // NIHMS FTP deposits will always be in the SUBMITTED state upon success, because there is no
-                    // way to determine the acceptability of the package simply by dropping it off at the FTP server
-                    //
-                    // So, the status of the Deposit might be REJECTED, ACCEPTED, or SUBMITTED, as long as it isn't
-                    // FAILED.
-                    if (terminalDepositStatusPolicy.accept(deposit.getDepositStatus()) ||
-                            deposit.getDepositStatus() == SUBMITTED) {
-                        return true;
-                    }
-
-                    LOG.debug("Postcondition for updating {} was not satisfied.  Expected " + "DepositDepositStatus " +
-                            "to be {}, {}, or {}, but was '{}'", ACCEPTED, REJECTED, SUBMITTED, deposit
-                            .getDepositStatus());
-                    return false;
-                },
-
-                (deposit) -> {
-                    if (dc.repoCopy() != null) {
-                        dc.repoCopy(passClient.createAndReadResource(dc.repoCopy(), RepositoryCopy.class));
-                        deposit.setRepositoryCopy(dc.repoCopy().getId());
-                        LOG.debug(">>>> Created repository copy for {}: {}", dc.deposit().getId(), dc.repoCopy().getId());
-                    }
-
-                    // the 'deposit' lambda parameter is a Deposit resource that has been retrieved from the repository.
-                    // If we have any state in the local DepositContext.deposit() that we want to be persisted in the
-                    // repository, it must be copied over from dc.deposit() to deposit.
-                    deposit.setDepositStatusRef(dc.deposit().getDepositStatusRef());
-                    deposit.setDepositStatus(dc.deposit().getDepositStatus());
-
-                    return dc.repoCopy();
-                });
-
-        if (!finalResult.success()) {
-            String msg = format("Failed to update Deposit tuple [%s, %s, %s]",
-                    dc.submission().getId(), dc.repository().getId(), dc.deposit().getId());
-            if (finalResult.throwable().isPresent()) {
-                Throwable t = finalResult.throwable().get();
-                msg = msg + ": " + t.getMessage();
-                throw new DepositServiceRuntimeException(msg, t, dc.deposit());
-            }
-
-            throw new DepositServiceRuntimeException(msg, dc.deposit());
+            // Determine the logical success or failure of the Deposit, and persist the Deposit and RepositoryCopy in
+            // the Fedora repository
+            depositHelper.processDepositStatus(dc.submission(), dc.repository(), dc.repoCopy(), dc.deposit());
         }
 
     }
 
-    public DepositUtil.DepositWorkerContext getDepositWorkerContext() {
+    private static RepositoryCopy newRepositoryCopy(DepositWorkerContext dc, String itemUri, CopyStatus copyStatus) {
+        RepositoryCopy repoCopy = new RepositoryCopy();
+        repoCopy.setCopyStatus(copyStatus);
+        repoCopy.setRepository(dc.repository().getId());
+        repoCopy.setPublication(dc.submission().getPublication());
+        if (itemUri != null) {
+            repoCopy.setExternalIds(Collections.singletonList(itemUri));
+            try {
+                repoCopy.setAccessUrl(new URI(itemUri));
+            } catch (URISyntaxException e) {
+                LOG.warn("Error creating an accessUrl from '{}' for a RepositoryCopy associated with {}",
+                        itemUri, dc.deposit().getId());
+            }
+        }
+        return repoCopy;
+    }
+
+    public DepositWorkerContext getDepositWorkerContext() {
         return dc;
+    }
+
+    public long getSwordSleepTimeMs() {
+        return swordSleepTimeMs;
+    }
+
+    public void setSwordSleepTimeMs(long swordSleepTimeMs) {
+        this.swordSleepTimeMs = swordSleepTimeMs;
     }
 
     @Override

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
@@ -23,25 +23,30 @@ import org.dataconservancy.pass.deposit.messaging.model.Packager;
 import org.dataconservancy.pass.deposit.messaging.model.Registry;
 import org.dataconservancy.pass.deposit.messaging.policy.Policy;
 import org.dataconservancy.pass.deposit.messaging.service.DepositUtil.DepositWorkerContext;
-import org.dataconservancy.pass.deposit.messaging.status.DepositStatusMapper;
-import org.dataconservancy.pass.deposit.messaging.status.DepositStatusParser;
-import org.dataconservancy.pass.deposit.messaging.status.SwordDspaceDepositStatus;
 import org.dataconservancy.pass.deposit.messaging.support.CriticalRepositoryInteraction;
+import org.dataconservancy.pass.deposit.messaging.support.CriticalRepositoryInteraction.CriticalResult;
 import org.dataconservancy.pass.model.Deposit;
 import org.dataconservancy.pass.model.Repository;
+import org.dataconservancy.pass.model.RepositoryCopy;
 import org.dataconservancy.pass.model.Submission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import static java.lang.Integer.toHexString;
 import static java.lang.String.format;
 import static java.lang.System.identityHashCode;
 import static org.dataconservancy.pass.deposit.messaging.service.DepositUtil.toDepositWorkerContext;
+import static org.dataconservancy.pass.model.Deposit.DepositStatus.ACCEPTED;
+import static org.dataconservancy.pass.model.Deposit.DepositStatus.REJECTED;
+import static org.dataconservancy.pass.model.Deposit.DepositStatus.SUBMITTED;
+import static org.dataconservancy.pass.model.RepositoryCopy.CopyStatus.IN_PROGRESS;
 
 /**
  * Encapsulates functionality common to performing the submission of a Deposit to the TaskExecutor.
@@ -62,37 +67,38 @@ public class DepositTaskHelper {
     public static final String MISSING_PACKAGER = ">>>> No Packager found for tuple [{}, {}, {}]: " +
             "Missing Packager for Repository named '{}', marking Deposit as FAILED.";
 
-    protected PassClient passClient;
+    private static final String PRECONDITION_FAILED = "Refusing to update {}, the following pre-condition failed: ";
 
-    protected Registry<Packager> packagerRegistry;
+    private static final String POSTCONDITION_FAILED = "Refusing to update {}, the following post-condition failed: ";
 
-    protected TaskExecutor taskExecutor;
+    private PassClient passClient;
 
-    protected DepositStatusMapper<SwordDspaceDepositStatus> depositStatusMapper;
+    private TaskExecutor taskExecutor;
 
-    protected DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser;
+    private Policy<Deposit.DepositStatus> intermediateDepositStatusPolicy;
 
-    protected Policy<Deposit.DepositStatus> intermediateDepositStatusPolicy;
+    private Policy<Deposit.DepositStatus> terminalDepositStatusPolicy;
 
-    protected Policy<Deposit.DepositStatus> terminalDepositStatusPolicy;
+    private CriticalRepositoryInteraction cri;
 
-    protected CriticalRepositoryInteraction critical;
+    @Value("${pass.deposit.transport.swordv2.sleep-time-ms}")
+    private long swordDepositSleepTimeMs;
+
+    private Registry<Packager> packagerRegistry;
 
     @Autowired
-    public DepositTaskHelper(PassClient passClient, Registry<Packager> packagerRegistry, TaskExecutor taskExecutor,
-                             DepositStatusMapper<SwordDspaceDepositStatus> depositStatusMapper,
-                             DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser,
+    public DepositTaskHelper(PassClient passClient,
+                             TaskExecutor taskExecutor,
                              Policy<Deposit.DepositStatus> intermediateDepositStatusPolicy,
                              Policy<Deposit.DepositStatus> terminalDepositStatusPolicy,
-                             CriticalRepositoryInteraction critical) {
+                             CriticalRepositoryInteraction cri,
+                             Registry<Packager> packagerRegistry) {
         this.passClient = passClient;
-        this.packagerRegistry = packagerRegistry;
         this.taskExecutor = taskExecutor;
-        this.depositStatusMapper = depositStatusMapper;
-        this.atomStatusParser = atomStatusParser;
         this.intermediateDepositStatusPolicy = intermediateDepositStatusPolicy;
         this.terminalDepositStatusPolicy = terminalDepositStatusPolicy;
-        this.critical = critical;
+        this.cri = cri;
+        this.packagerRegistry = packagerRegistry;
     }
 
     /**
@@ -102,6 +108,10 @@ public class DepositTaskHelper {
      * <p>
      * Note that the {@link DepositServiceErrorHandler} will be invoked to handle the {@code
      * DepositServiceRuntimeException}, which will attempt to mark the {@code Deposit} as FAILED.
+     * </p>
+     * <p>
+     * The {@code DepositTask} composed by this helper method will only accept {@code Deposit} resources with
+     * <em>intermediate</em> state.
      * </p>
      *
      * @param submission the submission that the {@code deposit} belongs to
@@ -116,8 +126,8 @@ public class DepositTaskHelper {
         try {
             DepositWorkerContext dc = toDepositWorkerContext(
                     deposit, submission, depositSubmission, repo, packager);
-            DepositTask depositTask = new DepositTask(dc, passClient, atomStatusParser, depositStatusMapper,
-                    intermediateDepositStatusPolicy, terminalDepositStatusPolicy, critical);
+            DepositTask depositTask = new DepositTask(dc, passClient, intermediateDepositStatusPolicy, cri, this);
+            depositTask.setSwordSleepTimeMs(swordDepositSleepTimeMs);
 
             LOG.debug(">>>> Submitting task ({}@{}) for tuple [{}, {}, {}]",
                     depositTask.getClass().getSimpleName(), toHexString(identityHashCode(depositTask)),
@@ -129,6 +139,235 @@ public class DepositTaskHelper {
                     (deposit == null) ? "null" : deposit.getId(), e.getMessage());
             throw new DepositServiceRuntimeException(msg, e, deposit);
         }
+    }
+
+    public void processDepositStatus(Deposit deposit) {
+       processDepositStatus(
+                passClient.readResource(deposit.getSubmission(), Submission.class),
+                passClient.readResource(deposit.getRepository(), Repository.class),
+                passClient.readResource(deposit.getRepositoryCopy(), RepositoryCopy.class), deposit);
+    }
+
+    void processDepositStatus(Submission submission, Repository repo, RepositoryCopy repoCopy, Deposit deposit) {
+
+        // Subtle issue to be aware of:
+        //
+        // The Deposit being passed into this method may contain state (e.g. a depositStatusRef) that is not
+        // present on the Deposit resource in the repository.  Therefore, the Deposit retrieved by the CRI may
+        // be out of date with respect to the Deposit provided to this method.
+        //
+        // At this time, the depositStatusRef is the only state that may differ.
+        //
+        // To insure that the depositStatusRef from the 'deposit' method parameter is stored on the 'deposit' from
+        // the CRI, the field is copied in the "critical update" lambda below.  This insures if a conflict arises,
+        // the ConflictHandler will retry the critical update, including the copy of the depositStatusRef.
+
+        CriticalResult<RepositoryCopy, Deposit> cr = cri.performCritical(deposit.getId(), Deposit.class,
+
+                /*
+                 * Preconditions:
+                 * - The depositStatusRef on the 'deposit' *supplied to this method* must not be null, and must be a URI
+                 * - The links between Deposit, Submission, Repository, and RepositoryCopy must be intact
+                 * - The Deposit must be in a SUBMITTED state.
+                 * - Insure a DepositStatusRefProcessor exists for the Repository
+                 */
+                (criDeposit) -> {
+                    if (criDeposit.getDepositStatus() != SUBMITTED) {
+                        LOG.warn(PRECONDITION_FAILED + " Expected Deposit.DepositStatus = {}, but was '{}'",
+                                SUBMITTED, deposit.getDepositStatus());
+                        return false;
+                    }
+
+                    if (!verifyNullityAndLinks(submission, repo, repoCopy, criDeposit)) {
+                        return false;
+                    }
+
+                    try {
+                        new URI(deposit.getDepositStatusRef());
+                    } catch (URISyntaxException|NullPointerException e) {
+                        LOG.warn(PRECONDITION_FAILED + " depositStatusRef must be a valid URI: {}",
+                                deposit.getId(), e.getMessage(), e);
+                        return false;
+                    }
+
+                    if (packagerRegistry.get(repo.getName()) == null || packagerRegistry.get(repo.getName())
+                            .getDepositStatusProcessor() == null) {
+                        LOG.warn(PRECONDITION_FAILED + " mising a DepositStatusRefProcessor for Repository with name " +
+                                "'{}' (id: '{}')", repo.getName(), repo.getId());
+                        return false;
+                    }
+
+                    return true;
+                },
+
+                /*
+                 * Postconditions:
+                 * - The criRepoCopy must not be null
+                 * - The criDeposit must have a depositStatusRef
+                 * - The criDeposit must be linked to the criRepoCopy
+                 * - The criDeposit cannot be in a FAILED state
+                 * - If the criDeposit is still in SUBMITTED state, then the RepositoryCopy must remain (or be in) an IN-PROGRESS state
+                 * - If the criDeposit is in a REJECTED state, then the RepositoryCopy must be in a REJECTED state
+                 * - If the criDeposit is in an ACCEPTED stated, then the RepositoryCopy must be in an ACCEPTED state
+                 */
+                (criDeposit, criRepoCopy) -> {
+                    if (criRepoCopy == null) {
+                        LOG.warn(POSTCONDITION_FAILED + " RepositoryCopy was null.");
+                        return false;
+                    }
+
+                    if (criDeposit.getDepositStatusRef() == null) {
+                        LOG.warn(POSTCONDITION_FAILED + " Deposit must have a depositStatusRef.");
+                        return false;
+                    }
+
+                    if (criDeposit.getRepositoryCopy() == null || !criDeposit.getRepositoryCopy().equals(criRepoCopy.getId())) {
+                        LOG.warn(POSTCONDITION_FAILED + " Deposit RepositoryCopy URI was '{}', and does not equal the" +
+                                " expected URI {}", criDeposit.getRepositoryCopy(), criRepoCopy.getId());
+                        return false;
+                    }
+
+                    // A SWORD deposit may have taken longer than 10s (they are async, after all), so the Deposit
+                    // may be in the SUBMITTED state still.
+                    //
+                    // NIHMS FTP deposits will always be in the SUBMITTED state upon success, because there is no
+                    // way to determine the acceptability of the package simply by dropping it off at the FTP server
+                    //
+                    // So, the status of the Deposit might be REJECTED, ACCEPTED, or SUBMITTED, as long as it isn't
+                    // FAILED.
+                    if (!terminalDepositStatusPolicy.accept(criDeposit.getDepositStatus()) &&
+                            criDeposit.getDepositStatus() != SUBMITTED) {
+                        LOG.warn(POSTCONDITION_FAILED + " Expected Deposit.DepositStatus to be {}, {}, or {}, but was '{}'",
+                                ACCEPTED, REJECTED, SUBMITTED, criDeposit.getDepositStatus());
+                        return false;
+                    }
+
+                    if (criDeposit.getDepositStatus() == SUBMITTED && repoCopy.getCopyStatus() != IN_PROGRESS) {
+                        LOG.warn(POSTCONDITION_FAILED + " Expected RepoCopy.CopyStatus = {}, but was '{}' for Deposit.DepositStatus = '{}'",
+                                IN_PROGRESS, criRepoCopy.getCopyStatus(), SUBMITTED);
+                        return false;
+                    }
+
+                    if (criDeposit.getDepositStatus() == REJECTED && criRepoCopy.getCopyStatus() != RepositoryCopy.CopyStatus.REJECTED) {
+                        LOG.warn(POSTCONDITION_FAILED + " Expected RepoCopy.CopyStatus = {}, but was '{}' for Deposit.DepositStatus = '{}'",
+                                RepositoryCopy.CopyStatus.REJECTED, criRepoCopy.getCopyStatus(), REJECTED);
+                        return false;
+                    }
+
+                    if (criDeposit.getDepositStatus() == ACCEPTED && criRepoCopy.getCopyStatus() != RepositoryCopy.CopyStatus.COMPLETE) {
+                        LOG.warn(POSTCONDITION_FAILED + " Expected RepoCopy.CopyStatus = {}, but was '{}' for Deposit.DepositStatus = '{}'",
+                                RepositoryCopy.CopyStatus.COMPLETE, criRepoCopy.getCopyStatus(), ACCEPTED);
+                        return false;
+                    }
+
+                    return true;
+                },
+
+                (criDeposit) -> {
+                    Deposit.DepositStatus status;
+
+                    criDeposit.setDepositStatusRef(deposit.getDepositStatusRef());
+
+                    try {
+                        DepositStatusRefProcessor depositStatusProcessor =
+                                packagerRegistry.get(repo.getName()).getDepositStatusProcessor();
+                        status = depositStatusProcessor.process(URI.create(criDeposit.getDepositStatusRef()));
+                    } catch (Exception e) {
+                        String msg = format("Failed to update deposit status for [%s], " +
+                                        "parsing the status document referenced by %s failed: %s",
+                                criDeposit.getId(), criDeposit.getDepositStatusRef(), e.getMessage());
+                        LOG.warn(msg, e);
+                        throw new DepositServiceRuntimeException(msg, e, criDeposit);
+                    }
+
+                    if (status == null) {
+                        String msg = format("Failed to update deposit status for [%s], " +
+                                        "mapping the status obtained from  %s failed",
+                                criDeposit.getId(), criDeposit.getDepositStatusRef());
+                        throw new DepositServiceRuntimeException(msg, criDeposit);
+                    }
+
+                    switch (status) {
+                        case ACCEPTED: {
+                            LOG.info("Deposit {} was accepted.", criDeposit.getId());
+                            criDeposit.setDepositStatus(ACCEPTED);
+                            repoCopy.setCopyStatus(RepositoryCopy.CopyStatus.COMPLETE);
+                            break;
+                        }
+
+                        case REJECTED: {
+                            LOG.info("Deposit {} was rejected.", criDeposit.getId());
+                            criDeposit.setDepositStatus(Deposit.DepositStatus.REJECTED);
+                            repoCopy.setCopyStatus(RepositoryCopy.CopyStatus.REJECTED);
+                            break;
+                        }
+                    }
+
+                    RepositoryCopy criRepoCopy;
+
+                    try {
+                        if (repoCopy.getId() == null) {
+                            criRepoCopy = passClient.createAndReadResource(repoCopy, RepositoryCopy.class);
+                        } else {
+                            criRepoCopy = passClient.updateAndReadResource(repoCopy, RepositoryCopy.class);
+                        }
+                        criDeposit.setRepositoryCopy(criRepoCopy.getId());
+                    } catch (Exception e) {
+                        String msg = String.format("Failed to create or update RepositoryCopy '%s' for %s",
+                                repoCopy.getId(), criDeposit.getId());
+                        throw new DepositServiceRuntimeException(msg, e, criDeposit);
+                    }
+
+                    return criRepoCopy;
+                });
+
+        if (!cr.success()) {
+            String msg = format("Failed to update Deposit tuple [%s, %s, %s]",
+                    submission.getId(), repo.getId(), deposit.getId());
+
+            if (cr.throwable().isPresent()) {
+                throw new DepositServiceRuntimeException(msg, cr.throwable().get(), deposit);
+            }
+
+            throw new DepositServiceRuntimeException(msg, deposit);
+        }
+    }
+
+    private static boolean verifyNullityAndLinks(Submission s, Repository r, RepositoryCopy rc, Deposit d) {
+        if (d.getDepositStatus() != SUBMITTED) {
+            LOG.warn(PRECONDITION_FAILED + " expected DepositStatus = '{}', but was '{}'",
+                    d.getId(), SUBMITTED, d.getDepositStatus());
+            return false;
+        }
+
+        if (rc.getId() != null && !rc.getId().equals(d.getRepositoryCopy())) {
+            LOG.warn(PRECONDITION_FAILED + " RepositoryCopy URI mismatch: deposit RepositoryCopy URI: '{}', supplied RepositoryCopy URI: '{}'",
+                    d.getId(), d.getRepositoryCopy(), rc.getId());
+            return false;
+        }
+
+        if (d.getSubmission() == null) {
+            LOG.warn(PRECONDITION_FAILED + " it has a 'null' Submission.", d.getId());
+            return false;
+        }
+
+        if (!s.getId().equals(d.getSubmission())) {
+            LOG.warn(PRECONDITION_FAILED + " Submission URI mismatch: deposit Submission URI: '{}', supplied Submission URI: '{}'",
+                    d.getId(), d.getSubmission(), s.getId());
+        }
+
+        if (d.getRepository() == null) {
+            LOG.warn(PRECONDITION_FAILED + " it has a 'null' Repository.", d.getId());
+            return false;
+        }
+
+        if (!r.getId().equals(d.getRepository())) {
+            LOG.warn(PRECONDITION_FAILED + " Repository URI mismatch: deposit Repository URI: '{}', supplied Repository URI: '{}'",
+                    d.getId(), d.getRepository(), r.getId());
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositUtil.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositUtil.java
@@ -158,6 +158,7 @@ public class DepositUtil {
      * @param jmsMessage the message, in the native JMS model
      * @return an Object with references to the context of an incoming JMS message
      */
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public static MessageContext toMessageContext(String resourceType, String eventType, long timestamp, String id, Session
             session, Message message, javax.jms.Message jmsMessage) {
         MessageContext mc = new MessageContext();

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/status/AbderaDepositStatusRefProcessor.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/status/AbderaDepositStatusRefProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.status;
+
+import org.dataconservancy.pass.deposit.messaging.service.DepositStatusRefProcessor;
+import org.dataconservancy.pass.model.Deposit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+/**
+ * Parses {@link Deposit.DepositStatus} from a SWORD statement document.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ * @see <a href="http://swordapp.github.io/SWORDv2-Profile/SWORDProfile.html#statement">SWORD v2 Profile §11</a>
+ */
+@Component
+public class AbderaDepositStatusRefProcessor implements DepositStatusRefProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbderaDepositStatusRefProcessor.class);
+
+    private DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser;
+
+    private DepositStatusMapper<SwordDspaceDepositStatus> swordDepositStatusMapper;
+
+    @Autowired
+    public AbderaDepositStatusRefProcessor(DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser,
+                                           DepositStatusMapper<SwordDspaceDepositStatus> swordDepositStatusMapper) {
+        this.atomStatusParser = atomStatusParser;
+        this.swordDepositStatusMapper = swordDepositStatusMapper;
+    }
+
+    /**
+     * Parses the SWORD statement at {@code depositStatusRef}, and returns a corresponding {@link Deposit.DepositStatus}
+     *
+     * @param depositStatusRef expected to be a {@code URI} referencing a SWORD statement
+     * @return the deposit status, may be {@code null}
+     */
+    @Override
+    public Deposit.DepositStatus process(URI depositStatusRef) {
+        SwordDspaceDepositStatus swordStatus = atomStatusParser.parse(depositStatusRef);
+
+        if (swordStatus == null) {
+            LOG.debug("Unable to parse the SWORD deposit status from {}, returning 'null' Deposit.DepositStatus",
+                    depositStatusRef);
+            return null;
+        }
+
+        Deposit.DepositStatus depositStatus = swordDepositStatusMapper.map(swordStatus);
+
+        if (depositStatus == null) {
+            LOG.debug("Unable to map the SWORD deposit status '{}' parsed from {} to a Deposit.DepositStatus.  " +
+                            "Returning 'null' Deposit.DepositStatus", swordStatus, depositStatusRef);
+            return null;
+        }
+
+        return depositStatus;
+    }
+}

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/status/SwordDspaceDepositStatusMapper.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/status/SwordDspaceDepositStatusMapper.java
@@ -38,7 +38,7 @@ public class SwordDspaceDepositStatusMapper extends AbstractStatusMapper<SwordDs
      * Maps a {@link SwordDspaceDepositStatus} to a {@link org.dataconservancy.pass.model.Deposit.DepositStatus}
      *
      * @param statusToMap the SWORD deposit status
-     * @return the corresponding PASS deposit status
+     * @return the corresponding PASS deposit status, may be {@code null}
      */
     @Override
     public Deposit.DepositStatus map(SwordDspaceDepositStatus statusToMap) {

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/CriticalPath.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/support/CriticalPath.java
@@ -116,6 +116,7 @@ public class CriticalPath implements CriticalRepositoryInteraction {
      *         any exception thrown, and the overall success as determined by the post-condition
      */
     @Override
+    @SuppressWarnings("unchecked")
     public <R, T extends PassEntity> CriticalResult<R, T> performCritical(URI uri, Class<T> clazz,
                                                                           Predicate<T> precondition,
                                                                           BiPredicate<T, R> postcondition,

--- a/deposit-messaging/src/main/resources/application.properties
+++ b/deposit-messaging/src/main/resources/application.properties
@@ -36,3 +36,5 @@ pass.deposit.status.mapping=classpath:/statusmapping.json
 pass.deposit.http.agent=pass-deposit/x.y.z
 pass.deposit.queue.deposit.name=deposit
 pass.deposit.queue.submission.name=submission
+# TODO probably should be configured on a repository-by-repository basis
+pass.deposit.transport.swordv2.sleep-time-ms=10000

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/PolicyTestUtil.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/policy/PolicyTestUtil.java
@@ -36,6 +36,7 @@ public class PolicyTestUtil {
         return withResourceAndEventType(resourceType, eventType, "software-agent-web-browser.json");
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     static DepositUtil.MessageContext withResourceAndEventType(String resourceType, String eventType, String
             messageBodyResource) throws IOException {
         DepositUtil.MessageContext mc = mock(DepositUtil.MessageContext.class);

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/AbstractSubmissionProcessorTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/AbstractSubmissionProcessorTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractSubmissionProcessorTest {
 
     SubmissionPolicy submissionPolicy;
 
-    Policy<Deposit.DepositStatus> dirtyDepositPolicy;
+    Policy<Deposit.DepositStatus> intermediateDepositStatusPolicy;
 
     Policy<Deposit.DepositStatus> terminalDepositStatusPolicy;
 
@@ -74,15 +74,14 @@ public abstract class AbstractSubmissionProcessorTest {
         submissionBuilder = mock(SubmissionBuilder.class);
         packagerRegistry = mock(Registry.class);
         submissionPolicy = mock(SubmissionPolicy.class);
-        dirtyDepositPolicy = mock(Policy.class);
+        intermediateDepositStatusPolicy = mock(Policy.class);
         messagePolicy = mock(JmsMessagePolicy.class);
         taskExecutor = mock(TaskExecutor.class);
         dspaceStatusMapper = mock(DepositStatusMapper.class);
         atomStatusParser = mock(DepositStatusParser.class);
         cri = mock(CriticalRepositoryInteraction.class);
         terminalDepositStatusPolicy = mock(Policy.class);
-        depositTaskHelper = new DepositTaskHelper(passClient, packagerRegistry, taskExecutor, dspaceStatusMapper,
-                atomStatusParser, dirtyDepositPolicy, terminalDepositStatusPolicy, cri);
+        depositTaskHelper = new DepositTaskHelper(passClient, taskExecutor, intermediateDepositStatusPolicy, terminalDepositStatusPolicy, cri, packagerRegistry);
     }
     
 }

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/DepositUtilTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/DepositUtilTest.java
@@ -108,6 +108,7 @@ public class DepositUtilTest {
     }
 
     @Test
+    @SuppressWarnings("rawtypes")
     public void toMessageContext() throws Exception {
         String rType = "resource_type";
         String eType = "event_type";

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/JmsSubmissionProcessorTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/JmsSubmissionProcessorTest.java
@@ -75,7 +75,7 @@ public class JmsSubmissionProcessorTest extends AbstractSubmissionProcessorTest 
         critical = mock(CriticalRepositoryInteraction.class);
 
         underTest = new JmsSubmissionProcessor(passClient, jsonParser, submissionBuilder, packagerRegistry,
-                submissionPolicy, dirtyDepositPolicy, terminalDepositStatusPolicy, messagePolicy, depositTaskHelper, dspaceStatusMapper, atomStatusParser, critical);
+                submissionPolicy, intermediateDepositStatusPolicy, terminalDepositStatusPolicy, messagePolicy, depositTaskHelper, dspaceStatusMapper, atomStatusParser, critical);
     }
 
     /**

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessorTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessorTest.java
@@ -65,7 +65,7 @@ public class SubmissionProcessorTest extends AbstractSubmissionProcessorTest {
     public void setUp() throws Exception {
         super.setUp();
         underTest = new SubmissionProcessor(passClient, jsonParser, submissionBuilder, packagerRegistry,
-                submissionPolicy, dirtyDepositPolicy, messagePolicy, terminalDepositStatusPolicy, depositTaskHelper, dspaceStatusMapper, atomStatusParser, cri);
+                submissionPolicy, intermediateDepositStatusPolicy, messagePolicy, terminalDepositStatusPolicy, depositTaskHelper, dspaceStatusMapper, atomStatusParser, cri);
     }
 
     /**

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessorTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/SubmissionProcessorTest.java
@@ -111,7 +111,7 @@ public class SubmissionProcessorTest extends AbstractSubmissionProcessorTest {
 
         // Mock the CRI that returns the "In-Progress" Submission and builds the DepositSubmission.
 
-        CriticalResult criResult = mock(CriticalResult.class);
+        CriticalResult<DepositSubmission, Submission> criResult = mock(CriticalResult.class);
         when(criResult.success()).thenReturn(true);
         when(criResult.resource()).thenReturn(Optional.of(submission));
         when(criResult.result()).thenReturn(Optional.of(depositSubmission));
@@ -179,7 +179,7 @@ public class SubmissionProcessorTest extends AbstractSubmissionProcessorTest {
 
         // Mock the CRI that returns the "In-Progress" Submission and builds the DepositSubmission.
 
-        CriticalResult criResult = mock(CriticalResult.class);
+        CriticalResult<DepositSubmission, Submission> criResult = mock(CriticalResult.class);
         when(criResult.success()).thenReturn(true);
         when(criResult.result()).thenReturn(Optional.of(new DepositSubmission()));
         when(cri.performCritical(any(), any(), any(), any(BiPredicate.class), any())).thenReturn(criResult);
@@ -210,7 +210,7 @@ public class SubmissionProcessorTest extends AbstractSubmissionProcessorTest {
 
         // Mock the CRI that returns the "In-Progress" Submission and builds the DepositSubmission.
 
-        CriticalResult criResult = mock(CriticalResult.class);
+        CriticalResult<DepositSubmission, Submission> criResult = mock(CriticalResult.class);
         when(criResult.resource()).thenReturn(Optional.of(submission));
         when(criResult.success()).thenReturn(true);
         when(cri.performCritical(any(), any(), any(), any(BiPredicate.class), any())).thenReturn(criResult);
@@ -248,7 +248,7 @@ public class SubmissionProcessorTest extends AbstractSubmissionProcessorTest {
         // Mock the CRI that returns the "In-Progress" Submission and builds the DepositSubmission.
         // In this test the CRI fails, for whatever reason.
 
-        CriticalResult criResult = mock(CriticalResult.class);
+        CriticalResult<DepositSubmission, Submission> criResult = mock(CriticalResult.class);
         when(criResult.success()).thenReturn(false);
         Exception expectedCause = new Exception("Failed CRI");
         when(criResult.throwable()).thenReturn(Optional.of(expectedCause));
@@ -286,7 +286,7 @@ public class SubmissionProcessorTest extends AbstractSubmissionProcessorTest {
 
         // Mock the CRI that returns the "In-Progress" Submission and builds the DepositSubmission.
 
-        CriticalResult criResult = mock(CriticalResult.class);
+        CriticalResult<DepositSubmission, Submission> criResult = mock(CriticalResult.class);
         when(criResult.success()).thenReturn(true);
         when(criResult.resource()).thenReturn(Optional.of(submission));
         when(criResult.result()).thenReturn(Optional.of(depositSubmission));
@@ -328,7 +328,7 @@ public class SubmissionProcessorTest extends AbstractSubmissionProcessorTest {
 
         // Mock the CRI that returns the "In-Progress" Submission and builds the DepositSubmission.
 
-        CriticalResult criResult = mock(CriticalResult.class);
+        CriticalResult<DepositSubmission, Submission> criResult = mock(CriticalResult.class);
         when(criResult.success()).thenReturn(true);
         when(criResult.resource()).thenReturn(Optional.of(submission));
         when(criResult.result()).thenReturn(Optional.of(depositSubmission));
@@ -385,7 +385,7 @@ public class SubmissionProcessorTest extends AbstractSubmissionProcessorTest {
 
         // Mock the CRI that returns the "In-Progress" Submission and builds the DepositSubmission.
 
-        CriticalResult criResult = mock(CriticalResult.class);
+        CriticalResult<DepositSubmission, Submission> criResult = mock(CriticalResult.class);
         when(criResult.success()).thenReturn(true);
         when(criResult.resource()).thenReturn(Optional.of(submission));
         when(criResult.result()).thenReturn(Optional.of(depositSubmission));

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/SubmittedStatusHandlingIT.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/SubmittedStatusHandlingIT.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.service;
+
+import org.dataconservancy.nihms.assembler.PackageStream;
+import org.dataconservancy.nihms.model.DepositFileType;
+import org.dataconservancy.nihms.transport.Transport;
+import org.dataconservancy.nihms.transport.TransportResponse;
+import org.dataconservancy.nihms.transport.TransportSession;
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.deposit.assembler.dspace.mets.DspaceMetsAssembler;
+import org.dataconservancy.pass.deposit.assembler.shared.AbstractAssembler;
+import org.dataconservancy.pass.deposit.assembler.shared.BaseAssemblerIT;
+import org.dataconservancy.pass.deposit.messaging.model.Packager;
+import org.dataconservancy.pass.deposit.messaging.model.Registry;
+import org.dataconservancy.pass.deposit.transport.sword2.Sword2DepositReceiptResponse;
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Repository;
+import org.dataconservancy.pass.model.RepositoryCopy;
+import org.dataconservancy.pass.model.Submission;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.dataconservancy.pass.model.Deposit.DepositStatus.ACCEPTED;
+import static org.dataconservancy.pass.model.Deposit.DepositStatus.SUBMITTED;
+import static org.dataconservancy.pass.model.RepositoryCopy.CopyStatus.COMPLETE;
+import static org.dataconservancy.pass.model.RepositoryCopy.CopyStatus.IN_PROGRESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = { "spring.jms.listener.auto-startup=false" })
+public class SubmittedStatusHandlingIT extends BaseAssemblerIT {
+
+    @Autowired
+    private DspaceMetsAssembler dspaceMetsAssembler;
+
+    @Autowired
+    private Registry<Packager> packagerRegistry;
+
+    @Autowired
+    private PassClient passClient;
+
+    @Autowired
+    DepositTaskHelper underTest;
+
+    private Deposit toUpdate;
+
+    @Override
+    public void setUp() throws Exception {
+
+        // Step 1: Create a PackageStream
+
+        mbf = metadataBuilderFactory();
+        rbf = resourceBuilderFactory();
+
+        Map<File, DepositFileType> custodialContentWithTypes = prepareCustodialResources();
+
+        submission = prepareSubmission(custodialContentWithTypes);
+
+        PackageStream stream = dspaceMetsAssembler.assemble(submission);
+
+        // Step 2: Deposit the Package to DSpace.
+
+        Packager packager = packagerRegistry.get("JScholarship");
+        Transport transport = packager.getTransport();
+        TransportSession session = transport.open(packager.getConfiguration());
+        Sword2DepositReceiptResponse tr = (Sword2DepositReceiptResponse) session.send(stream, packager
+                .getConfiguration());
+        assertTrue(tr.success());
+
+        // 2a. Keep a reference to the SWORD Statement
+
+        URI swordStatement = tr.getReceipt().getAtomStatementLink().getIRI().toURI();
+
+        // 2.b Keep a reference to the DSpace Item URL
+
+        URI dspaceItem = tr.getReceipt().getSplashPageLink().getIRI().toURI();
+
+        // Step 3: Manufacture a Deposit and RepositoryCopy for this test (normally created by the SubmissionProcessor)
+
+        Submission submissionResource = new Submission();
+
+        Deposit deposit = new Deposit();
+        deposit.setDepositStatusRef(swordStatement.toString());
+        deposit.setDepositStatus(SUBMITTED);
+        deposit.setSubmission(submissionResource.getId());
+
+        Repository repo = new Repository();
+        repo.setName("JScholarship");
+
+        repo = passClient.createAndReadResource(repo, Repository.class);
+
+        RepositoryCopy rc = new RepositoryCopy();
+        rc.setCopyStatus(RepositoryCopy.CopyStatus.IN_PROGRESS);
+        rc.setAccessUrl(dspaceItem);
+        rc.setExternalIds(Collections.singletonList(dspaceItem.toString()));
+
+        submissionResource = passClient.createAndReadResource(submissionResource, Submission.class);
+
+        rc = passClient.createAndReadResource(rc, RepositoryCopy.class);
+
+        deposit.setRepositoryCopy(rc.getId());
+        deposit.setSubmission(submissionResource.getId());
+        deposit.setRepository(repo.getId());
+
+        toUpdate = passClient.createAndReadResource(deposit, Deposit.class);
+    }
+
+    @Override
+    protected AbstractAssembler assemblerUnderTest() {
+        return dspaceMetsAssembler;
+    }
+
+    @Override
+    protected void verifyStreamMetadata(PackageStream.Metadata metadata) {
+        // no-op, we don't care.  we are simply re-using the logic in BaseAssemblerIT to
+        // produce a package
+    }
+
+    @Test
+    public void processStatusFromSubmittedToAccepted() throws Exception {
+        assertEquals(SUBMITTED, toUpdate.getDepositStatus());
+        assertEquals(IN_PROGRESS,
+                passClient.readResource(toUpdate.getRepositoryCopy(), RepositoryCopy.class).getCopyStatus());
+
+        underTest.processDepositStatus(toUpdate);
+
+        Deposit deposit = passClient.readResource(toUpdate.getId(), Deposit.class);
+        RepositoryCopy repoCopy = passClient.readResource(deposit.getRepositoryCopy(), RepositoryCopy.class);
+
+        assertEquals(ACCEPTED, deposit.getDepositStatus());
+        assertEquals(COMPLETE, repoCopy.getCopyStatus());
+    }
+}

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/status/AbderaDepositStatusRefProcessorTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/status/AbderaDepositStatusRefProcessorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.status;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class AbderaDepositStatusRefProcessorTest {
+
+    private AbderaDepositStatusRefProcessor underTest;
+
+    private URI atomStatementUri = URI.create("http://example.org/statement.atom");
+
+    private DepositStatusParser<URI, SwordDspaceDepositStatus> atomStatusParser;
+
+    private DepositStatusMapper<SwordDspaceDepositStatus> swordDepositStatusMapper;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        atomStatusParser = mock(DepositStatusParser.class);
+        swordDepositStatusMapper = mock(DepositStatusMapper.class);
+        underTest = new AbderaDepositStatusRefProcessor(atomStatusParser, swordDepositStatusMapper);
+    }
+
+    @Test
+    public void parsingReturnsNullSwordStatus() throws Exception {
+        when(atomStatusParser.parse(any())).thenReturn(null);
+
+        assertNull(underTest.process(atomStatementUri));
+
+        verify(atomStatusParser).parse(any());
+        verifyZeroInteractions(swordDepositStatusMapper);
+    }
+
+    @Test
+    public void mappingReturnsNullDepositStatus() throws Exception {
+        when(atomStatusParser.parse(any())).thenReturn(SwordDspaceDepositStatus.SWORD_STATE_INPROGRESS);
+        when(swordDepositStatusMapper.map(SwordDspaceDepositStatus.SWORD_STATE_INPROGRESS)).thenReturn(null);
+
+        assertNull(underTest.process(atomStatementUri));
+
+        verify(atomStatusParser).parse(any());
+        verify(swordDepositStatusMapper).map(SwordDspaceDepositStatus.SWORD_STATE_INPROGRESS);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void parsingThrowsRuntimeException() throws Exception {
+        when(atomStatusParser.parse(any())).thenThrow(new RuntimeException("Expected"));
+
+        underTest.process(atomStatementUri);
+
+        verify(atomStatusParser).parse(any());
+        verifyZeroInteractions(swordDepositStatusMapper);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void mappingThrowsRuntimeException() throws Exception {
+        when(atomStatusParser.parse(any())).thenReturn(SwordDspaceDepositStatus.SWORD_STATE_INPROGRESS);
+        when(swordDepositStatusMapper.map(SwordDspaceDepositStatus.SWORD_STATE_INPROGRESS))
+                .thenThrow(new RuntimeException("Expected"));
+
+        assertNull(underTest.process(atomStatementUri));
+
+        verify(atomStatusParser).parse(any());
+        verify(swordDepositStatusMapper).map(SwordDspaceDepositStatus.SWORD_STATE_INPROGRESS);
+    }
+}


### PR DESCRIPTION
Implement the refreshing of a Deposit status.
    
- Implements SubmittedUpdateRunner, invoked by the `refresh` command line argument
- Refactors DepositTask and the DepositTaskHelper to allow processing of the deposit status reference outside of SubmissionProcessor (e.g. by SubmittedUpdateRunner)
- Necessitates the creation of a RepositoryCopy in the IN_PROGRESS state as soon as a Deposit is performed, in order to store the DSpace Item URL.
- This is required because the DSpace SWORD receipt is not retrievable; the SWORD server does not make the receipt available except when performing the initial deposit.

Additionally:
- Clean up some warnings issued when compiling
- Makes the sleep time between a SWORD deposit and processing of the SWORD receipt configurable (default is 10 seconds, unchanged from previous behavior)
- A new abstraction `DepositStatusReferenceProcessor` and an implementation based on Apache Abdera are included