### PR TITLE
Support workaround for unusable J10P SWORD URLs

### DIFF
--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTask.java
@@ -214,8 +214,8 @@ public class DepositTask implements Runnable {
 
                 if (prefixToMatch != null && statementUri.startsWith(prefixToMatch)) {
                     String newUri = statementUri.replace(prefixToMatch, replacementPrefix);
-                    statementUri  = newUri;
                     LOG.trace("Replacing Atom Statement URI '{}' with '{}'", statementUri, newUri);
+                    statementUri  = newUri;
                 } else {
                     LOG.trace("Prefix '{}' did not match Atom Statement URI '{}', no replacement will take place.",
                             prefixToMatch == null ? "<null>" : prefixToMatch, statementUri);

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
@@ -84,6 +84,12 @@ public class DepositTaskHelper {
     @Value("${pass.deposit.transport.swordv2.sleep-time-ms}")
     private long swordDepositSleepTimeMs;
 
+    @Value("${jscholarship.hack.sword.statement.uri-prefix}")
+    private String statementUriPrefix;
+
+    @Value("${jscholarship.hack.sword.statement.uri-replacement}")
+    private String statementUriReplacement;
+
     private Registry<Packager> packagerRegistry;
 
     @Autowired
@@ -128,6 +134,8 @@ public class DepositTaskHelper {
                     deposit, submission, depositSubmission, repo, packager);
             DepositTask depositTask = new DepositTask(dc, passClient, intermediateDepositStatusPolicy, cri, this);
             depositTask.setSwordSleepTimeMs(swordDepositSleepTimeMs);
+            depositTask.setPrefixToMatch(statementUriPrefix);
+            depositTask.setReplacementPrefix(statementUriReplacement);
 
             LOG.debug(">>>> Submitting task ({}@{}) for tuple [{}, {}, {}]",
                     depositTask.getClass().getSimpleName(), toHexString(identityHashCode(depositTask)),

--- a/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
+++ b/deposit-messaging/src/main/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelper.java
@@ -341,6 +341,22 @@ public class DepositTaskHelper {
         }
     }
 
+    String getStatementUriPrefix() {
+        return statementUriPrefix;
+    }
+
+    void setStatementUriPrefix(String statementUriPrefix) {
+        this.statementUriPrefix = statementUriPrefix;
+    }
+
+    String getStatementUriReplacement() {
+        return statementUriReplacement;
+    }
+
+    void setStatementUriReplacement(String statementUriReplacement) {
+        this.statementUriReplacement = statementUriReplacement;
+    }
+
     private static boolean verifyNullityAndLinks(Submission s, Repository r, RepositoryCopy rc, Deposit d) {
         if (d.getDepositStatus() != SUBMITTED) {
             LOG.warn(PRECONDITION_FAILED + " expected DepositStatus = '{}', but was '{}'",

--- a/deposit-messaging/src/main/resources/application.properties
+++ b/deposit-messaging/src/main/resources/application.properties
@@ -38,3 +38,6 @@ pass.deposit.queue.deposit.name=deposit
 pass.deposit.queue.submission.name=submission
 # TODO probably should be configured on a repository-by-repository basis
 pass.deposit.transport.swordv2.sleep-time-ms=10000
+
+jscholarship.hack.sword.statement.uri-prefix=http://dspace-prod.mse.jhu.edu:8080/swordv2/
+jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.jhu.edu/swordv2/

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelperTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskHelperTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.service;
+
+import org.dataconservancy.nihms.model.DepositSubmission;
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.deposit.messaging.model.Packager;
+import org.dataconservancy.pass.deposit.messaging.model.Registry;
+import org.dataconservancy.pass.deposit.messaging.policy.Policy;
+import org.dataconservancy.pass.deposit.messaging.support.CriticalRepositoryInteraction;
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Repository;
+import org.dataconservancy.pass.model.Submission;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.core.task.TaskExecutor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class DepositTaskHelperTest {
+
+    private PassClient passClient;
+
+    private TaskExecutor taskExecutor;
+
+    private Policy<Deposit.DepositStatus> intermediateDepositStatusPolicy;
+
+    private Policy<Deposit.DepositStatus> terminalDepositStatusPolicy;
+
+    private CriticalRepositoryInteraction cri;
+
+    private Registry<Packager> packagerRegistry;
+
+    private Submission s;
+
+    private DepositSubmission ds;
+
+    private Repository r;
+
+    private Packager p;
+
+    private Deposit d;
+
+    private DepositTaskHelper underTest;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        passClient = mock(PassClient.class);
+        taskExecutor = mock(TaskExecutor.class);
+        intermediateDepositStatusPolicy = mock(Policy.class);
+        terminalDepositStatusPolicy = mock(Policy.class);
+        cri = mock(CriticalRepositoryInteraction.class);
+        packagerRegistry = mock(Registry.class);
+
+        underTest = new DepositTaskHelper(passClient, taskExecutor, intermediateDepositStatusPolicy,
+                terminalDepositStatusPolicy, cri, packagerRegistry);
+
+        s = mock(Submission.class);
+        ds = mock(DepositSubmission.class);
+        d = mock(Deposit.class);
+        r = mock(Repository.class);
+        p = mock(Packager.class);
+    }
+
+    @Test
+    public void j10sStatementUrlHackWithNullValues() throws Exception {
+        ArgumentCaptor<DepositTask> dtCaptor = ArgumentCaptor.forClass(DepositTask.class);
+
+        underTest.submitDeposit(s, ds, r, d, p);
+
+        verify(taskExecutor).execute(dtCaptor.capture());
+
+        DepositTask depositTask = dtCaptor.getValue();
+        assertNotNull(depositTask);
+
+        assertNull(depositTask.getPrefixToMatch());
+        assertNull(depositTask.getReplacementPrefix());
+    }
+
+    @Test
+    public void j10sStatementUrlHack() throws Exception {
+        ArgumentCaptor<DepositTask> dtCaptor = ArgumentCaptor.forClass(DepositTask.class);
+        String prefix = "moo";
+        String replacement = "foo";
+
+        underTest.setStatementUriPrefix(prefix);
+        underTest.setStatementUriReplacement(replacement);
+        underTest.submitDeposit(s, ds, r, d, p);
+
+        verify(taskExecutor).execute(dtCaptor.capture());
+
+        DepositTask depositTask = dtCaptor.getValue();
+        assertNotNull(depositTask);
+
+        assertEquals(prefix, depositTask.getPrefixToMatch());
+        assertEquals(replacement, depositTask.getReplacementPrefix());
+    }
+
+}

--- a/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskTest.java
+++ b/deposit-messaging/src/test/java/org/dataconservancy/pass/deposit/messaging/service/DepositTaskTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dataconservancy.pass.deposit.messaging.service;
+
+import org.apache.abdera.i18n.iri.IRI;
+import org.dataconservancy.pass.client.PassClient;
+import org.dataconservancy.pass.deposit.messaging.policy.Policy;
+import org.dataconservancy.pass.deposit.messaging.support.CriticalRepositoryInteraction;
+import org.dataconservancy.pass.deposit.transport.sword2.Sword2DepositReceiptResponse;
+import org.dataconservancy.pass.model.Deposit;
+import org.dataconservancy.pass.model.Repository;
+import org.dataconservancy.pass.model.Submission;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.swordapp.client.DepositReceipt;
+import org.swordapp.client.SWORDClientException;
+import org.swordapp.client.SwordIdentifier;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public class DepositTaskTest {
+
+    private DepositUtil.DepositWorkerContext dc;
+
+    private PassClient passClient;
+
+    private Policy<Deposit.DepositStatus> intermediateDepositStatusPolicy;
+
+    private CriticalRepositoryInteraction cri;
+
+    private DepositTaskHelper depositHelper;
+
+    private DepositTask underTest;
+
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setUp() throws Exception {
+        dc = mock(DepositUtil.DepositWorkerContext.class);
+        passClient = mock(PassClient.class);
+        intermediateDepositStatusPolicy = mock(Policy.class);
+        cri = mock(CriticalRepositoryInteraction.class);
+        depositHelper = mock(DepositTaskHelper.class);
+        underTest = new DepositTask(dc, passClient, intermediateDepositStatusPolicy, cri, depositHelper);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void j10sStatementUrlHack() throws Exception {
+        ArgumentCaptor<String> depositStatusRef = ArgumentCaptor.forClass(String.class);
+        String prefix = "http://moo";
+        String replacement = "http://foo";
+
+        Deposit d = depositContext(dc);
+        Sword2DepositReceiptResponse tr = transportResponse();
+        criSuccess(d, tr, cri);
+        DepositReceipt depositReceipt = depositReceipt(tr);
+        SwordIdentifier statementLink = identifierFor(prefix);
+        when(depositReceipt.getAtomStatementLink()).thenReturn(statementLink);
+
+        underTest.setSwordSleepTimeMs(1); // move things along...
+        underTest.setReplacementPrefix(replacement);
+        underTest.setPrefixToMatch(prefix);
+
+        underTest.run();
+
+        verify(d).setDepositStatusRef(depositStatusRef.capture());
+
+        assertEquals(replacement, depositStatusRef.getValue());
+    }
+
+    @Test
+    public void j10sStatementUrlHackWithNullValues() throws Exception {
+        ArgumentCaptor<String> depositStatusRef = ArgumentCaptor.forClass(String.class);
+        String prefix = "http://moo";
+
+        Deposit d = depositContext(dc);
+        Sword2DepositReceiptResponse tr = transportResponse();
+        criSuccess(d, tr, cri);
+        DepositReceipt depositReceipt = depositReceipt(tr);
+        SwordIdentifier statementLink = identifierFor(prefix);
+        when(depositReceipt.getAtomStatementLink()).thenReturn(statementLink);
+
+        underTest.setSwordSleepTimeMs(1); // move things along...
+        underTest.setReplacementPrefix(null);
+        underTest.setPrefixToMatch(null);
+
+        underTest.run();
+
+        verify(d).setDepositStatusRef(depositStatusRef.capture());
+
+        assertEquals(prefix, depositStatusRef.getValue());
+    }
+
+    @Test
+    public void j10sStatementUrlHackWithNonMatchingValues() throws Exception {
+        ArgumentCaptor<String> depositStatusRef = ArgumentCaptor.forClass(String.class);
+        String href = "http://baz";
+        String prefix = "http://moo";
+        String replacement = "http://foo";
+
+        Deposit d = depositContext(dc);
+        Sword2DepositReceiptResponse tr = transportResponse();
+        criSuccess(d, tr, cri);
+        DepositReceipt depositReceipt = depositReceipt(tr);
+        SwordIdentifier statementLink = identifierFor(href);
+        when(depositReceipt.getAtomStatementLink()).thenReturn(statementLink);
+
+        underTest.setSwordSleepTimeMs(1); // move things along...
+        underTest.setReplacementPrefix(replacement);
+        underTest.setPrefixToMatch(prefix);
+        assertNotEquals(href, prefix);
+
+        underTest.run();
+
+        verify(d).setDepositStatusRef(depositStatusRef.capture());
+
+        assertEquals(href, depositStatusRef.getValue());
+    }
+
+    /**
+     * Populates the supplied {@code depositContext} with a mock {@code Repository}, {@code Submission} and
+     * {@code Deposit}.
+     *
+     * @param depositContext
+     * @return
+     */
+    private static Deposit depositContext(DepositUtil.DepositWorkerContext depositContext) {
+        Repository r = mock(Repository.class);
+        when(r.getId()).thenReturn(URI.create("uuid:" + UUID.randomUUID().toString()));
+        Submission s = mock(Submission.class);
+        when(depositContext.submission()).thenReturn(s);
+        when(depositContext.repository()).thenReturn(r);
+        Deposit d = mock(Deposit.class);
+        when(depositContext.deposit()).thenReturn(d);
+        return d;
+    }
+
+    /**
+     * Mocks a successful CRI that answers the supplied {@code deposit} as the CRI {@code resource()} and the supplied
+     * {@code transportResponse} as the CRI {@code response()}.
+     *
+     * @param deposit
+     * @param transportResponse
+     * @param cri
+     */
+    @SuppressWarnings("unchecked")
+    private static void criSuccess(Deposit deposit, Sword2DepositReceiptResponse transportResponse, CriticalRepositoryInteraction cri) {
+        CriticalRepositoryInteraction.CriticalResult cr = mock(CriticalRepositoryInteraction.CriticalResult.class);
+        when(cr.success()).thenReturn(true);
+        when(cr.resource()).thenReturn(Optional.of(deposit));
+        when(cr.result()).thenReturn(Optional.of(transportResponse));
+        when(cri.performCritical(any(), eq(Deposit.class), any(Predicate.class), any(BiPredicate.class),
+                any(Function.class))).thenReturn(cr);
+    }
+
+    /**
+     * Answers a mock {@link DepositReceipt} that is attached to the supplied {@link Sword2DepositReceiptResponse}
+     *
+     * @param tr
+     * @return
+     */
+    private static DepositReceipt depositReceipt(Sword2DepositReceiptResponse tr) {
+        DepositReceipt depositReceipt = mock(DepositReceipt.class);
+        when(tr.getReceipt()).thenReturn(depositReceipt);
+        return depositReceipt;
+    }
+
+    /**
+     * Answers a mock {@link Sword2DepositReceiptResponse}
+     *
+     * @return
+     */
+    private static Sword2DepositReceiptResponse transportResponse() {
+        return mock(Sword2DepositReceiptResponse.class);
+    }
+
+    /**
+     * Answers a mock {@link SwordIdentifier} that returns an {@code IRI} from the supplied {@code href}
+     *
+     * @param href
+     * @return
+     * @throws SWORDClientException
+     */
+    private static SwordIdentifier identifierFor(String href) throws SWORDClientException {
+        SwordIdentifier identifier = mock(SwordIdentifier.class);
+        when(identifier.getIRI()).thenReturn(new IRI(href));
+        return identifier;
+    }
+}


### PR DESCRIPTION
Currently JScholarship (J10P) returns [SWORD Deposit Receipts](http://swordapp.github.io/SWORDv2-Profile/SWORDProfile.html#depositreceipt) containing URLs in the response body that cannot be resolved, in the form of `http://dspace-prod.mse.jhu.edu:8080/swordv2/....`.

1. The `.mse.jhu.edu` domain is not resolvable by the public Internet
2. Port `8080` is not available to the public Internet 

However, J10S _will_ answer to another form of `http://dspace-prod.mse.jhu.edu...` URLs: `https://jscholarship.library.jhu.edu/swordv2/...`:
* The `.library.jhu.edu` domain is resolvable by the public Internet
* Port 443 is available to the public Internet

This PR includes a "special" hack for J10P.  If an impotent SWORD Statement URI is observed in a  [SWORD Deposit Receipt](http://swordapp.github.io/SWORDv2-Profile/SWORDProfile.html#depositreceipt) (i.e. matching `http://dspace-prod.mse.jhu.edu:8080/swordv2/....`), the public form of the URI will be used instead (i.e. `https://jscholarship.library.jhu.edu/swordv2/...`).

The real solution is to fix J10P, and have it advertise resolvable URLs, whatever they may be.  Until then, this hack is in place.

The following properties are baked in as defaults, but can be overridden at runtime if desired.

* `jscholarship.hack.sword.statement.uri-prefix=http://dspace-prod.mse.jhu.edu:8080/swordv2/`
* `jscholarship.hack.sword.statement.uri-replacement=https://jscholarship.library.jhu.edu/swordv2/`
